### PR TITLE
Add Range (slider) component for value selection on a continuum

### DIFF
--- a/src/activity-levels.json
+++ b/src/activity-levels.json
@@ -607,6 +607,12 @@
       "atomic-category": "component",
       "mediation": "individual"
     },
+    "operations-range": {
+      "activity-level": "operation",
+      "lifecycle-stage": null,
+      "atomic-category": "primitive",
+      "mediation": "individual"
+    },
     "operations-reference": {
       "activity-level": "operation",
       "lifecycle-stage": null,
@@ -821,6 +827,12 @@
       "activity-level": "action",
       "lifecycle-stage": "evaluation",
       "atomic-category": "component",
+      "mediation": "individual"
+    },
+    "operations-counter": {
+      "activity-level": "operation",
+      "lifecycle-stage": null,
+      "atomic-category": "primitive",
       "mediation": "individual"
     },
     "operations-details": {

--- a/src/components/range/range.css
+++ b/src/components/range/range.css
@@ -1,0 +1,198 @@
+:host {
+  display: block;
+
+  --range-fill: var(--c-accent-600);
+  --range-track-color: var(--c-border);
+  --range-track-height: var(--space-xs);
+  --range-thumb-size: 1rem;
+  --range-mark-size: 2px;
+  --range-mark-color: var(--c-border);
+}
+
+.range {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-s);
+  width: 100%;
+  font-family: inherit;
+  vertical-align: middle;
+}
+
+.range__track-wrapper {
+  position: relative;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.range__control {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}
+
+.range__control:focus {
+  outline: none;
+}
+
+/* Track — WebKit */
+.range__control::-webkit-slider-runnable-track {
+  height: var(--range-track-height);
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    to right,
+    var(--range-fill) 0%,
+    var(--range-fill) var(--range-percent, 0%),
+    var(--range-track-color) var(--range-percent, 0%),
+    var(--range-track-color) 100%
+  );
+  transition: var(--transition-fast) background-color;
+}
+
+/* Track — Firefox */
+.range__control::-moz-range-track {
+  height: var(--range-track-height);
+  border-radius: var(--radius-pill);
+  background: var(--range-track-color);
+}
+
+.range__control::-moz-range-progress {
+  height: var(--range-track-height);
+  border-radius: var(--radius-pill);
+  background: var(--range-fill);
+}
+
+/* Thumb — WebKit */
+.range__control::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--range-thumb-size);
+  height: var(--range-thumb-size);
+  margin-top: calc((var(--range-track-height) - var(--range-thumb-size)) / 2);
+  border: none;
+  border-radius: var(--radius-circle);
+  background: var(--range-fill);
+  cursor: grab;
+  transition: var(--transition-fast) transform, var(--transition-fast) box-shadow;
+}
+
+.range__control:active::-webkit-slider-thumb {
+  cursor: grabbing;
+  transform: scale(1.1);
+}
+
+/* Thumb — Firefox */
+.range__control::-moz-range-thumb {
+  width: var(--range-thumb-size);
+  height: var(--range-thumb-size);
+  border: none;
+  border-radius: var(--radius-circle);
+  background: var(--range-fill);
+  cursor: grab;
+  transition: var(--transition-fast) transform, var(--transition-fast) box-shadow;
+}
+
+.range__control:active::-moz-range-thumb {
+  cursor: grabbing;
+  transform: scale(1.1);
+}
+
+/* Focus ring */
+.range--focused .range__control::-webkit-slider-thumb {
+  box-shadow: 0 0 0 var(--focus-ring-width) var(--focus-ring-color);
+}
+
+.range--focused .range__control::-moz-range-thumb {
+  box-shadow: 0 0 0 var(--focus-ring-width) var(--focus-ring-color);
+}
+
+/* Hover */
+.range:hover:not(.range--disabled) .range__control::-webkit-slider-thumb {
+  background: var(--c-active-border);
+}
+
+.range:hover:not(.range--disabled) .range__control::-moz-range-thumb {
+  background: var(--c-active-border);
+}
+
+/* Disabled */
+.range--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.range--disabled .range__control {
+  cursor: not-allowed;
+}
+
+.range--disabled .range__control::-webkit-slider-thumb {
+  cursor: not-allowed;
+}
+
+.range--disabled .range__control::-moz-range-thumb {
+  cursor: not-allowed;
+}
+
+/* Marks */
+.range__marks {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  margin-inline: calc(var(--range-thumb-size) / 2);
+}
+
+.range__mark {
+  position: absolute;
+  top: 50%;
+  width: var(--range-mark-size);
+  height: var(--range-mark-size);
+  margin-top: calc(var(--range-mark-size) / -2);
+  margin-inline-start: calc(var(--range-mark-size) / -2);
+  border-radius: var(--radius-circle);
+  background: var(--range-mark-color);
+}
+
+/* Prefix / suffix */
+.range__prefix,
+.range__suffix {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  color: var(--c-secondary);
+  white-space: nowrap;
+}
+
+.range__value {
+  font-variant-numeric: tabular-nums;
+  color: var(--c-body);
+  min-width: 2ch;
+  text-align: end;
+}
+
+/* Sizes */
+.range--small {
+  --range-track-height: calc(var(--space-xs) * 0.75);
+  --range-thumb-size: 0.75rem;
+
+  font-size: var(--text-xs);
+}
+
+.range--medium {
+  --range-track-height: var(--space-xs);
+  --range-thumb-size: 1rem;
+
+  font-size: var(--text-s);
+}
+
+.range--large {
+  --range-track-height: calc(var(--space-xs) * 1.5);
+  --range-thumb-size: 1.25rem;
+
+  font-size: var(--text-m);
+}

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -69,7 +69,8 @@ export class PpRange extends LitElement {
     if (this.value > this.max) this.value = this.max;
   }
 
-  private handleInput = () => {
+  private handleInput = (event: Event) => {
+    event.stopPropagation();
     this.value = Number(this.input.value);
     this.dispatchEvent(new CustomEvent('input', {
       detail: { value: this.value },
@@ -86,24 +87,26 @@ export class PpRange extends LitElement {
     this.hasFocus = false;
   };
 
-  focus(options?: FocusOptions) {
-    this.input.focus(options);
+  async focus(options?: FocusOptions) {
+    await this.updateComplete;
+    this.input?.focus(options);
   }
 
-  blur() {
-    this.input.blur();
+  async blur() {
+    await this.updateComplete;
+    this.input?.blur();
   }
 
   private renderMarks() {
     if (!this.marks || this.step <= 0) return '';
     const span = this.max - this.min;
     if (span <= 0) return '';
-    const count = Math.floor(span / this.step);
+    const count = Math.floor(span / this.step + 1e-9);
     if (count <= 0) return '';
     const ticks = [];
     for (let i = 0; i <= count; i++) {
       const percent = (i * this.step / span) * 100;
-      ticks.push(html`<span class="range__mark" style="left: ${percent}%"></span>`);
+      ticks.push(html`<span class="range__mark" style="inset-inline-start: ${percent}%"></span>`);
     }
     return html`<div part="marks" class="range__marks" aria-hidden="true">${ticks}</div>`;
   }

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -1,0 +1,182 @@
+import { html, LitElement, unsafeCSS } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { live } from 'lit/directives/live.js';
+import { property, query, state } from 'lit/decorators.js';
+import type { CSSResultGroup } from 'lit';
+import styles from './range.css?inline';
+
+/**
+ * @summary Range lets the actor commit to a value on a continuum by direct manipulation.
+ * @status draft
+ * @since 0.0.1
+ *
+ * @slot prefix - Leading unit, min label, or icon.
+ * @slot suffix - Trailing unit, max label, live value readout, or icon.
+ *
+ * @csspart base - The component's base wrapper.
+ * @csspart input - The internal `<input type="range">` control.
+ * @csspart track - The track (styled via documented custom properties).
+ * @csspart thumb - The thumb (styled via documented custom properties).
+ * @csspart marks - The container rendered when `marks` is true.
+ * @csspart prefix - The container that wraps the prefix slot.
+ * @csspart suffix - The container that wraps the suffix slot.
+ *
+ * @cssproperty --range-fill - Colour of the filled portion of the track. Defaults to `--c-accent-600`.
+ * @cssproperty --range-track-color - Colour of the unfilled track. Defaults to `--c-border`.
+ * @cssproperty --range-thumb-size - Diameter of the thumb. Defaults to `1rem`.
+ */
+
+export interface RangeProps {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+}
+
+export class PpRange extends LitElement {
+  static styles: CSSResultGroup = [unsafeCSS(styles)];
+
+  @query('.range__control') input!: HTMLInputElement;
+
+  @state() private hasFocus = false;
+
+  @property({ type: Number, reflect: true }) min = 0;
+  @property({ type: Number, reflect: true }) max = 100;
+  @property({ type: Number }) step = 1;
+  @property({ type: Number, reflect: true }) value = 0;
+  @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'medium';
+  @property({ type: Boolean, reflect: true }) disabled = false;
+  @property() name = '';
+  @property() label = '';
+  @property() labelledby = '';
+  @property() describedby = '';
+  @property({ type: Boolean, reflect: true }) marks = false;
+  @property({ type: Boolean, attribute: 'hide-value', reflect: true }) hideValue = false;
+  @property({ attribute: 'value-text' }) valueText = '';
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (document.readyState !== 'loading') {
+      this.init();
+      return;
+    }
+    document.addEventListener('DOMContentLoaded', () => this.init());
+  }
+
+  private init() {
+    if (this.value < this.min) this.value = this.min;
+    if (this.value > this.max) this.value = this.max;
+  }
+
+  private handleInput = () => {
+    this.value = Number(this.input.value);
+    this.dispatchEvent(new CustomEvent('input', {
+      detail: { value: this.value },
+      bubbles: true,
+      composed: true,
+    }));
+  };
+
+  private handleFocus = () => {
+    this.hasFocus = true;
+  };
+
+  private handleBlur = () => {
+    this.hasFocus = false;
+  };
+
+  focus(options?: FocusOptions) {
+    this.input.focus(options);
+  }
+
+  blur() {
+    this.input.blur();
+  }
+
+  private renderMarks() {
+    if (!this.marks || this.step <= 0) return '';
+    const span = this.max - this.min;
+    if (span <= 0) return '';
+    const count = Math.floor(span / this.step);
+    if (count <= 0) return '';
+    const ticks = [];
+    for (let i = 0; i <= count; i++) {
+      const percent = (i * this.step / span) * 100;
+      ticks.push(html`<span class="range__mark" style="left: ${percent}%"></span>`);
+    }
+    return html`<div part="marks" class="range__marks" aria-hidden="true">${ticks}</div>`;
+  }
+
+  render() {
+    const span = this.max - this.min;
+    const percent = span > 0 ? ((this.value - this.min) / span) * 100 : 0;
+
+    return html`
+      <div
+        part="form-control"
+        class=${classMap({
+      'form-control': true,
+      'form-control--small': this.size === 'small',
+      'form-control--medium': this.size === 'medium',
+      'form-control--large': this.size === 'large',
+    })}
+      >
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${classMap({
+      range: true,
+      'range--small': this.size === 'small',
+      'range--medium': this.size === 'medium',
+      'range--large': this.size === 'large',
+      'range--disabled': this.disabled,
+      'range--focused': this.hasFocus,
+      'range--with-marks': this.marks,
+    })}
+            style="--range-percent: ${percent}%"
+          >
+            <span part="prefix" class="range__prefix">
+              <slot name="prefix"></slot>
+            </span>
+
+            <div class="range__track-wrapper">
+              <input
+                part="input"
+                id="input"
+                class="range__control"
+                type="range"
+                name=${ifDefined(this.name || undefined)}
+                min=${this.min}
+                max=${this.max}
+                step=${this.step}
+                ?disabled=${this.disabled}
+                .value=${live(String(this.value))}
+                aria-label=${ifDefined(this.label || undefined)}
+                aria-labelledby=${ifDefined(this.labelledby || undefined)}
+                aria-describedby=${ifDefined(this.describedby || undefined)}
+                aria-valuetext=${ifDefined(this.valueText || undefined)}
+                @input=${this.handleInput}
+                @focus=${this.handleFocus}
+                @blur=${this.handleBlur}
+              />
+              ${this.renderMarks()}
+            </div>
+
+            <span part="suffix" class="range__suffix">
+              <slot name="suffix">
+                ${this.hideValue ? '' : html`<span class="range__value" aria-hidden="true">${this.value}</span>`}
+              </slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "pp-range": PpRange;
+  }
+}

--- a/src/components/register-all.ts
+++ b/src/components/register-all.ts
@@ -11,6 +11,7 @@ import { componentRegistry } from './component-registry.js';
 import { PpAvatar } from './avatar/avatar.js';
 import { PpButton } from './button/button.js';
 import { PpInput } from './input/input.js';
+import { PpRange } from './range/range.js';
 import { PpSelect } from './select/select.js';
 import { PPModal } from './modal/modal.js';
 import { PpToast } from './toast/toast.js';
@@ -44,6 +45,7 @@ export function registerAllComponents(): void {
     { tagName: 'pp-avatar', constructor: PpAvatar },
     { tagName: 'pp-button', constructor: PpButton, options: { extends: 'button' } },
     { tagName: 'pp-input', constructor: PpInput },
+    { tagName: 'pp-range', constructor: PpRange },
     { tagName: 'pp-select', constructor: PpSelect },
     { tagName: 'pp-toast', constructor: PpToast },
     { tagName: 'pp-tooltip', constructor: PpTooltip },

--- a/src/jsx-types.ts
+++ b/src/jsx-types.ts
@@ -15,6 +15,21 @@ declare module 'react' {
         autofocus?: boolean;
         type?: 'text' | 'email' | 'password' | 'number' | 'search' | 'tel' | 'url' | 'date' | 'datetime-local' | 'time';
       };
+      'pp-range': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        name?: string;
+        value?: number | string;
+        min?: number | string;
+        max?: number | string;
+        step?: number | string;
+        disabled?: boolean;
+        size?: 'small' | 'medium' | 'large';
+        label?: string;
+        labelledby?: string;
+        describedby?: string;
+        marks?: boolean;
+        'hide-value'?: boolean;
+        'value-text'?: string;
+      };
       'pp-select': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
         name?: string;
         value?: string;

--- a/src/pattern-graph.json
+++ b/src/pattern-graph.json
@@ -607,6 +607,12 @@
       "path": "../?path=/docs/operations-progress-indicator--docs"
     },
     {
+      "id": "operations-range",
+      "title": "Range",
+      "category": "Operations",
+      "path": "../?path=/docs/operations-range--docs"
+    },
+    {
       "id": "operations-reference",
       "title": "Reference",
       "category": "Operations",
@@ -821,6 +827,12 @@
       "title": "List",
       "category": "Actions",
       "path": "../?path=/docs/actions-evaluation-list--docs"
+    },
+    {
+      "id": "operations-counter",
+      "title": "Counter",
+      "category": "Operations",
+      "path": "../?path=/docs/operations-counter--docs"
     },
     {
       "id": "operations-details",
@@ -3605,6 +3617,10 @@
       "target": "operations-textarea"
     },
     {
+      "source": "operations-input",
+      "target": "operations-range"
+    },
+    {
       "source": "operations-overflow",
       "target": "actions-coordination-priority"
     },
@@ -3659,6 +3675,30 @@
     {
       "source": "operations-progress-indicator",
       "target": "actions-evaluation-timeline"
+    },
+    {
+      "source": "operations-progress-indicator",
+      "target": "operations-range"
+    },
+    {
+      "source": "operations-range",
+      "target": "operations-input"
+    },
+    {
+      "source": "operations-range",
+      "target": "operations-progress-indicator"
+    },
+    {
+      "source": "operations-range",
+      "target": "operations-counter"
+    },
+    {
+      "source": "operations-range",
+      "target": "actions-application-data-entry"
+    },
+    {
+      "source": "operations-range",
+      "target": "actions-application-form"
     },
     {
       "source": "operations-reference",

--- a/src/pattern-graph.json
+++ b/src/pattern-graph.json
@@ -3677,16 +3677,8 @@
       "target": "actions-evaluation-timeline"
     },
     {
-      "source": "operations-progress-indicator",
-      "target": "operations-range"
-    },
-    {
       "source": "operations-range",
       "target": "operations-input"
-    },
-    {
-      "source": "operations-range",
-      "target": "operations-progress-indicator"
     },
     {
       "source": "operations-range",

--- a/src/stories/actions/application/Form.stories.tsx
+++ b/src/stories/actions/application/Form.stories.tsx
@@ -51,7 +51,10 @@ export const Conversational: Story = {
         <div className="message__content">
           <div className="message__body layer">
             <div className="flex">
-              <span>0</span><input type="range" id="range" name="range" min="0" max="100" /><span>100</span>
+              <pp-range name="range" min={0} max={100} value={50}>
+                <span slot="prefix">0</span>
+                <span slot="suffix">100</span>
+              </pp-range>
               <button className="button button--plain" is="pp-button">
                 <iconify-icon className="icon" icon="ph:check"></iconify-icon><span className="inclusively-hidden">Submit</span>
               </button>

--- a/src/stories/operations/Input.mdx
+++ b/src/stories/operations/Input.mdx
@@ -52,3 +52,4 @@ For more complex cases an [autocomplete](../?path=/docs/operations-autocomplete-
 
 ### Related primitives
 - [Textarea](../?path=/docs/operations-textarea--docs) — the multi-line counterpart for longer free-form text
+- [Range](../?path=/docs/operations-range--docs) — commits to a value on a continuum by direct manipulation rather than by typing

--- a/src/stories/operations/ProgressIndicator.mdx
+++ b/src/stories/operations/ProgressIndicator.mdx
@@ -24,3 +24,4 @@ TODO: horizontal
 - [Breadcrumbs](../components/Breadcrumbs.mdx../?path=/docs/operations-breadcrumbs--docs) offer navigational context for large, hierarchical topologies.
 - [Wizard](../compositions/Wizard.mdx../?path=/docs/actions-application-wizard--docs) uses progress indicators for linear process flows.
 - [Timeline](../?path=/docs/actions-evaluation-timeline--docs) visualises events chronologically.
+- [Range](../?path=/docs/operations-range--docs) shares the track metaphor, but captures actor input where progress communicates system state.

--- a/src/stories/operations/ProgressIndicator.mdx
+++ b/src/stories/operations/ProgressIndicator.mdx
@@ -24,4 +24,3 @@ TODO: horizontal
 - [Breadcrumbs](../components/Breadcrumbs.mdx../?path=/docs/operations-breadcrumbs--docs) offer navigational context for large, hierarchical topologies.
 - [Wizard](../compositions/Wizard.mdx../?path=/docs/actions-application-wizard--docs) uses progress indicators for linear process flows.
 - [Timeline](../?path=/docs/actions-evaluation-timeline--docs) visualises events chronologically.
-- [Range](../?path=/docs/operations-range--docs) shares the track metaphor, but captures actor input where progress communicates system state.

--- a/src/stories/operations/Range.mdx
+++ b/src/stories/operations/Range.mdx
@@ -53,7 +53,6 @@ Wrapping a native `<input type="range">` inherits `role="slider"`, `aria-valuemi
 
 ### Related primitives
 - [Input](../?path=/docs/operations-input--docs) — typed numeric entry when the actor already knows the exact value.
-- [Progress indicator](../?path=/docs/operations-progress-indicator--docs) — shares the track metaphor but reports *system* state where a slider captures *actor* input.
 - [Counter](../?path=/docs/operations-counter--docs) — announces the numeric state a slider changes; useful as a passive readout alongside direct manipulation.
 
 ### Applied in

--- a/src/stories/operations/Range.mdx
+++ b/src/stories/operations/Range.mdx
@@ -1,7 +1,7 @@
 import { Canvas, Controls, Description, Meta, Story } from '@storybook/addon-docs/blocks';
 import * as RangeStories from './Range.stories.tsx';
 
-> 🥱 **Fun meter: boring**. An old primitive, but the question of when to offer a slider instead of a number field stays alive — it's a bet about what kind of knowing the actor has.
+> 🥱 **Fun meter: boring**. An old primitive, but the question of when to offer a slider instead of a number field stays alive.
 
 # Range
 
@@ -62,8 +62,7 @@ Wrapping a native `<input type="range">` inherits `role="slider"`, `aria-valuemi
 
 ## Resources & references
 
-- [Open UI — Slider research](https://open-ui.org/components/slider.research/) and [Parts breakdown](https://open-ui.org/components/slider.research.parts/)
-- [W3C ARIA Authoring Practices — Slider pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/)
-- [Apple Human Interface Guidelines — Sliders](https://developer.apple.com/design/human-interface-guidelines/sliders)
-- [Nordhealth Design — Range](https://nordhealth.design/components/range/)
-- [andreruffert / range-slider-element](https://github.com/andreruffert/range-slider-element)
+- [Open UI](https://open-ui.org/components/slider.research/) and [Parts breakdown](https://open-ui.org/components/slider.research.parts/)
+- [W3C ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/slider/)
+- [Apple HIG](https://developer.apple.com/design/human-interface-guidelines/sliders)
+- [Nordhealth Design](https://nordhealth.design/components/range/)

--- a/src/stories/operations/Range.mdx
+++ b/src/stories/operations/Range.mdx
@@ -1,0 +1,69 @@
+import { Canvas, Controls, Description, Meta, Story } from '@storybook/addon-docs/blocks';
+import * as RangeStories from './Range.stories.tsx';
+
+> 🥱 **Fun meter: boring**. An old primitive, but the question of when to offer a slider instead of a number field stays alive — it's a bet about what kind of knowing the actor has.
+
+# Range
+
+<Meta title="Operations/Range" of={RangeStories} tags={['activity-level:operation', 'atomic:primitive', 'mediation:individual']} />
+
+Commit to a value on a continuum by direct manipulation — trading numeric precision for spatial reasoning.
+
+<Canvas>
+  <Story of={RangeStories.Default} />
+</Canvas>
+
+A slider is appropriate when the actor's knowledge of the scale is approximate rather than exact — turning a volume down until it feels right, nudging a price ceiling until the result set looks sensible. When the value is already known precisely (a year of birth, a line count), a number input respects that certainty better.
+
+## Label and hint
+
+<Story of={RangeStories.WithLabelAndHint} />
+
+## Marks
+
+Visible tick marks turn a continuous scale into a discrete-feeling one. Use them when the `step` carries meaning the actor should see — preset tiers, discrete grades — rather than every time `step` is coarse.
+
+<Story of={RangeStories.WithMarks} />
+
+## Prefix and suffix
+
+*Prefix* and *suffix* slots hold units, endpoint labels, or icons. With `hide-value`, the default numeric readout is suppressed so the slot can carry a formatted value instead.
+
+<Story of={RangeStories.WithPrefixAndSuffix} />
+
+## Formatted value
+
+When the display value is formatted (currency, units, categorical labels), pass the formatted string as `value-text`. Screen readers announce this instead of the raw number, keeping the spoken form aligned with the visual one.
+
+<Story of={RangeStories.FormattedValue} />
+
+## Size
+
+<Story of={RangeStories.Sizes} />
+
+## Disabled
+
+<Story of={RangeStories.Disabled} />
+
+## Accessibility
+
+Wrapping a native `<input type="range">` inherits `role="slider"`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and the full keyboard contract: arrow keys step, *Page Up*/*Page Down* jump by a larger increment, *Home*/*End* snap to the bounds. Touch and pointer drag come for free. The one thing the primitive exposes deliberately is `value-text` — the hook for `aria-valuetext` — so that formatted values stay legible to assistive technology.
+
+## Related patterns
+
+### Related primitives
+- [Input](../?path=/docs/operations-input--docs) — typed numeric entry when the actor already knows the exact value.
+- [Progress indicator](../?path=/docs/operations-progress-indicator--docs) — shares the track metaphor but reports *system* state where a slider captures *actor* input.
+- [Counter](../?path=/docs/operations-counter--docs) — announces the numeric state a slider changes; useful as a passive readout alongside direct manipulation.
+
+### Applied in
+- [Data entry](../?path=/docs/actions-application-data-entry--docs) — the broader activity, where slider-vs-input is the key choice.
+- [Form](../?path=/docs/actions-application-form--docs) — the common container.
+
+## Resources & references
+
+- [Open UI — Slider research](https://open-ui.org/components/slider.research/) and [Parts breakdown](https://open-ui.org/components/slider.research.parts/)
+- [W3C ARIA Authoring Practices — Slider pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/)
+- [Apple Human Interface Guidelines — Sliders](https://developer.apple.com/design/human-interface-guidelines/sliders)
+- [Nordhealth Design — Range](https://nordhealth.design/components/range/)
+- [andreruffert / range-slider-element](https://github.com/andreruffert/range-slider-element)

--- a/src/stories/operations/Range.stories.tsx
+++ b/src/stories/operations/Range.stories.tsx
@@ -1,0 +1,203 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect, useRef, useState } from "react";
+
+interface RangeArgs {
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  disabled: boolean;
+  size: 'small' | 'medium' | 'large';
+}
+
+const meta = {
+  title: "Operations/Range",
+  tags: ['autodocs', 'activity-level:operation', 'atomic:primitive', 'mediation:individual'],
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Accessible label (aria-label on the internal input)',
+    },
+    min: {
+      control: { type: 'number' },
+      description: 'Minimum value',
+    },
+    max: {
+      control: { type: 'number' },
+      description: 'Maximum value',
+    },
+    step: {
+      control: { type: 'number' },
+      description: 'Increment between steps',
+    },
+    value: {
+      control: { type: 'number' },
+      description: 'Current value',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disabled state',
+    },
+    size: {
+      control: { type: 'radio' },
+      options: ['small', 'medium', 'large'],
+      description: 'Track and thumb size',
+    },
+  },
+} satisfies Meta<RangeArgs>;
+
+export default meta;
+type Story = StoryObj<RangeArgs>;
+
+function ControlledRange(props: RangeArgs) {
+  const ref = useRef<HTMLElement>(null);
+  const [value, setValue] = useState(props.value);
+
+  useEffect(() => setValue(props.value), [props.value]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ value: number }>).detail;
+      if (detail) setValue(detail.value);
+    };
+    el.addEventListener('input', handler);
+    return () => el.removeEventListener('input', handler);
+  }, []);
+
+  return (
+    <pp-range
+      ref={ref}
+      label={props.label}
+      min={props.min}
+      max={props.max}
+      step={props.step}
+      value={value}
+      disabled={props.disabled}
+      size={props.size}
+    />
+  );
+}
+
+export const Default: Story = {
+  args: {
+    label: 'Volume',
+    min: 0,
+    max: 100,
+    step: 1,
+    value: 50,
+    disabled: false,
+    size: 'medium',
+  },
+  render: (args) => <ControlledRange {...args} />,
+};
+
+/**
+ * Shadow DOM inputs can't be associated with a `<label for="…">` — the label can't
+ * reach across the shadow boundary. Use `aria-labelledby` and `aria-describedby`
+ * instead: give the label and hint elements `id`s and pass them through.
+ */
+export const WithLabelAndHint: Story = {
+  render: () => (
+    <div className="flow">
+      <label id="brightness-label" htmlFor="">Brightness</label>
+      <pp-range
+        labelledby="brightness-label"
+        describedby="brightness-help"
+        min={0}
+        max={100}
+        value={60}
+      />
+      <small id="brightness-help">Adjusts the display brightness across the entire interface.</small>
+    </div>
+  ),
+};
+
+export const WithMarks: Story = {
+  render: () => (
+    <pp-range
+      label="Difficulty"
+      min={0}
+      max={10}
+      step={1}
+      value={4}
+      marks
+    />
+  ),
+};
+
+export const WithPrefixAndSuffix: Story = {
+  render: () => (
+    <pp-range
+      label="Price ceiling"
+      min={0}
+      max={1000}
+      step={10}
+      value={250}
+      hide-value
+    >
+      <iconify-icon icon="ph:currency-gbp" slot="prefix" />
+      <small slot="suffix">£1000</small>
+    </pp-range>
+  ),
+};
+
+/**
+ * When the displayed value is formatted (currency, units, labels), pass the
+ * formatted string as `value-text` so screen readers announce the formatted
+ * form rather than the raw number.
+ */
+export const FormattedValue: Story = {
+  render: () => {
+    function FormattedRange() {
+      const ref = useRef<HTMLElement>(null);
+      const [value, setValue] = useState(50);
+      const formatted = `£${value}`;
+
+      useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        const handler = (event: Event) => {
+          const detail = (event as CustomEvent<{ value: number }>).detail;
+          if (detail) setValue(detail.value);
+        };
+        el.addEventListener('input', handler);
+        return () => el.removeEventListener('input', handler);
+      }, []);
+
+      return (
+        <pp-range
+          ref={ref}
+          label="Monthly budget"
+          min={0}
+          max={200}
+          step={5}
+          value={value}
+          hide-value
+          value-text={formatted}
+        >
+          <span slot="suffix">{formatted}</span>
+        </pp-range>
+      );
+    }
+    return <FormattedRange />;
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flow">
+      <pp-range label="Small" min={0} max={100} value={30} size="small" />
+      <pp-range label="Medium" min={0} max={100} value={50} size="medium" />
+      <pp-range label="Large" min={0} max={100} value={70} size="large" />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <pp-range label="Locked" min={0} max={100} value={40} disabled />
+  ),
+};

--- a/src/stories/operations/Range.stories.tsx
+++ b/src/stories/operations/Range.stories.tsx
@@ -102,7 +102,7 @@ export const Default: Story = {
 export const WithLabelAndHint: Story = {
   render: () => (
     <div className="flow">
-      <label id="brightness-label" htmlFor="">Brightness</label>
+      <label id="brightness-label">Brightness</label>
       <pp-range
         labelledby="brightness-label"
         describedby="brightness-help"

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,6 +12,21 @@ declare global {
         autofocus?: boolean;
         type?: 'text' | 'email' | 'password' | 'number' | 'search' | 'tel' | 'url' | 'date' | 'datetime-local' | 'time';
       };
+      'pp-range': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        name?: string;
+        value?: number | string;
+        min?: number | string;
+        max?: number | string;
+        step?: number | string;
+        disabled?: boolean;
+        size?: 'small' | 'medium' | 'large';
+        label?: string;
+        labelledby?: string;
+        describedby?: string;
+        marks?: boolean;
+        'hide-value'?: boolean;
+        'value-text'?: string;
+      };
       'pp-select': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
         name?: string;
         value?: string;


### PR DESCRIPTION
## Summary
Introduces a new `pp-range` component — a slider primitive that lets users commit to a value on a continuum through direct manipulation. This is a foundational operation component for scenarios where spatial reasoning is preferred over numeric precision (e.g., volume control, price filtering).

## Key Changes

- **New Range component** (`src/components/range/`)
  - `range.ts`: LitElement-based web component wrapping a native `<input type="range">`
  - `range.css`: Comprehensive styling with CSS custom properties for customization, supporting three size variants (small, medium, large)
  - Full accessibility support: native slider role, keyboard navigation (arrow keys, Page Up/Down, Home/End), ARIA attributes including `aria-valuetext` for formatted values

- **Storybook documentation** (`src/stories/operations/Range.stories.tsx` and `Range.mdx`)
  - Default story with controlled component pattern
  - Examples: label + hint, tick marks, prefix/suffix slots, formatted values, size variants, disabled state
  - Comprehensive MDX documentation with accessibility notes and related pattern references

- **Type definitions** 
  - Added `pp-range` JSX/React type definitions to `src/jsx-types.ts` and `src/types.d.ts`
  - Supports all component properties: `value`, `min`, `max`, `step`, `size`, `disabled`, `label`, `labelledby`, `describedby`, `marks`, `hide-value`, `value-text`

- **Component registration and metadata**
  - Registered in `src/components/register-all.ts`
  - Added to `src/pattern-graph.json` with relationships to Input, Progress Indicator, Counter, and form-related patterns
  - Added to `src/activity-levels.json` as an operation-level primitive

## Notable Implementation Details

- Uses Lit's `live()` directive to maintain input value synchronization while allowing user interaction
- Emits custom `input` events with detail containing the numeric value
- Supports both aria-label and aria-labelledby/aria-describedby for flexible labeling across shadow DOM boundaries
- Track fill percentage calculated via CSS custom property (`--range-percent`) for visual feedback
- Tick marks rendered conditionally based on `marks` property and step value
- Includes focus ring styling and hover states for enhanced UX
- Properly handles initialization to clamp value within min/max bounds

https://claude.ai/code/session_01W5xvoWvz9PUUXKyrUnqf2i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new range slider component with customizable min/max values, optional tick marks, prefix/suffix labels, and size variants (small, medium, large).
  * Supports disabled states, formatted value announcements, and full accessibility features.

* **Documentation**
  * Added comprehensive documentation with usage examples and accessibility guidance.
  * Updated cross-references to related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->