### PR TITLE
Enable agent mode for doc gardening workflow

### DIFF
--- a/.github/workflows/doc-garden.yml
+++ b/.github/workflows/doc-garden.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Run doc gardening
         uses: anthropics/claude-code-action@beta
         with:
+          mode: agent
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: |
             Walk AGENTS.md, ARCHITECTURE.md, and docs/. For each claim about file paths,


### PR DESCRIPTION
## Summary
Updated the doc gardening GitHub Actions workflow to enable agent mode when running the Claude code action.

## Changes
- Added `mode: agent` configuration to the Claude code action in the doc-garden workflow
  - This enables the agent mode for the documentation gardening task that validates file path claims in AGENTS.md, ARCHITECTURE.md, and docs/

## Details
The agent mode allows the Claude code action to operate with enhanced capabilities when performing the doc gardening validation task. This change ensures the workflow uses the appropriate execution mode for walking through documentation files and verifying path references.

https://claude.ai/code/session_01EzFqtaNpWytBwNb8aicw7z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->