### PR TITLE
Rename "Content" foundation to "Prose" across pattern graph

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -30,10 +30,10 @@ Research inputs for pattern development. Each entry summarises what the project 
 - `DIRA.md` — Bergström & Hornbæk's DIRA model of the user interface (Devices, Interaction Techniques, Representations, Assemblies).
   *Project takeaway*: a structural decomposition of what a UI *is*, independent of paradigm. Useful as an analytical frame when the project's patterns need positioning relative to the UI as a whole — which element of the interface does a given pattern primarily act on?
 
-## Content and rhetoric
+## Prose and rhetoric
 
 - `rhetoric-of-hyperlink.md` — Venkatesh Rao's 2009 *Ribbonfarm* essay on the hyperlink as rhetorical technology.
-  *Project takeaway*: authored links are prose moves, not references. Three modes — citation, form-content blending, figure-ground-voice integration — give the library a vocabulary for what "hard" (author-placed) linking does. "Yielding the stage" reads larger than linking: it names an authorial stance that trusts the reader to construct meaning, mirroring the library's human-centric [agency](../src/stories/qualities/Agency.mdx) framing from the author's side. Primary citation in the `Content` foundation's § *Stance and voice* and § *Link rhetoric* sections.
+  *Project takeaway*: authored links are prose moves, not references. Three modes — citation, form-content blending, figure-ground-voice integration — give the library a vocabulary for what "hard" (author-placed) linking does. "Yielding the stage" reads larger than linking: it names an authorial stance that trusts the reader to construct meaning, mirroring the library's human-centric [agency](../src/stories/qualities/Agency.mdx) framing from the author's side. Primary citation in the `Prose` foundation's § *Stance and voice* and § *Link rhetoric* sections.
 
 ## Harness engineering
 

--- a/src/activity-levels.json
+++ b/src/activity-levels.json
@@ -457,12 +457,6 @@
       "atomic-category": "foundations",
       "mediation": null
     },
-    "foundations-content": {
-      "activity-level": "cross-cutting",
-      "lifecycle-stage": null,
-      "atomic-category": "foundations",
-      "mediation": null
-    },
     "foundations-data-information": {
       "activity-level": "cross-cutting",
       "lifecycle-stage": null,
@@ -488,6 +482,12 @@
       "mediation": null
     },
     "foundations-modality": {
+      "activity-level": "cross-cutting",
+      "lifecycle-stage": null,
+      "atomic-category": "foundations",
+      "mediation": null
+    },
+    "foundations-prose": {
       "activity-level": "cross-cutting",
       "lifecycle-stage": null,
       "atomic-category": "foundations",

--- a/src/pattern-graph.json
+++ b/src/pattern-graph.json
@@ -457,12 +457,6 @@
       "path": "../?path=/docs/foundations-collaboration--docs"
     },
     {
-      "id": "foundations-content",
-      "title": "Content",
-      "category": "Foundations",
-      "path": "../?path=/docs/foundations-content--docs"
-    },
-    {
       "id": "foundations-data-information",
       "title": "Data & Information",
       "category": "Foundations",
@@ -491,6 +485,12 @@
       "title": "Modality",
       "category": "Foundations",
       "path": "../?path=/docs/foundations-modality--docs"
+    },
+    {
+      "id": "foundations-prose",
+      "title": "Prose",
+      "category": "Foundations",
+      "path": "../?path=/docs/foundations-prose--docs"
     },
     {
       "id": "foundations-material-color",
@@ -2144,10 +2144,6 @@
     },
     {
       "source": "actions-seeking-dynamic-hyperlinks",
-      "target": "foundations-content"
-    },
-    {
-      "source": "actions-seeking-dynamic-hyperlinks",
       "target": "actions-application-suggestion"
     },
     {
@@ -3191,102 +3187,6 @@
       "target": "qualities-formality"
     },
     {
-      "source": "foundations-content",
-      "target": "foundations-information-architecture"
-    },
-    {
-      "source": "foundations-content",
-      "target": "qualities-formality"
-    },
-    {
-      "source": "foundations-content",
-      "target": "activities-localization"
-    },
-    {
-      "source": "foundations-content",
-      "target": "actions-sensemaking-explanation"
-    },
-    {
-      "source": "foundations-content",
-      "target": "qualities-agency"
-    },
-    {
-      "source": "foundations-content",
-      "target": "qualities-learnability"
-    },
-    {
-      "source": "foundations-content",
-      "target": "activities-transparent-reasoning"
-    },
-    {
-      "source": "foundations-content",
-      "target": "activities-ai-tuning"
-    },
-    {
-      "source": "foundations-content",
-      "target": "actions-seeking-dynamic-hyperlinks"
-    },
-    {
-      "source": "foundations-content",
-      "target": "operations-reference"
-    },
-    {
-      "source": "foundations-content",
-      "target": "operations-deep-linking"
-    },
-    {
-      "source": "foundations-content",
-      "target": "actions-application-data-entry"
-    },
-    {
-      "source": "foundations-content",
-      "target": "operations-status-feedback"
-    },
-    {
-      "source": "foundations-content",
-      "target": "operations-toast"
-    },
-    {
-      "source": "foundations-content",
-      "target": "operations-callout"
-    },
-    {
-      "source": "foundations-content",
-      "target": "actions-coordination-notification"
-    },
-    {
-      "source": "foundations-content",
-      "target": "foundations-intent-interaction"
-    },
-    {
-      "source": "foundations-content",
-      "target": "foundations-collaboration"
-    },
-    {
-      "source": "foundations-content",
-      "target": "foundations-assistance"
-    },
-    {
-      "source": "foundations-content",
-      "target": "foundations-delegation"
-    },
-    {
-      "source": "foundations-content",
-      "target": "qualities-conversation"
-    },
-    {
-      "source": "foundations-content",
-      "target": "actions-application-suggestion"
-    },
-    {
-      "source": "foundations-content",
-      "target": "activities-bot"
-    },
-    {
-      "source": "foundations-content",
-      "target": "activities-generated-content"
-    },
-    {
       "source": "foundations-data-information",
       "target": "qualities-agency"
     },
@@ -3301,6 +3201,10 @@
     {
       "source": "foundations-data-information",
       "target": "foundations-information-architecture"
+    },
+    {
+      "source": "foundations-data-information",
+      "target": "foundations-prose"
     },
     {
       "source": "foundations-delegation",
@@ -3340,7 +3244,7 @@
     },
     {
       "source": "foundations-information-architecture",
-      "target": "foundations-content"
+      "target": "foundations-prose"
     },
     {
       "source": "foundations-information-architecture",
@@ -3477,6 +3381,102 @@
     {
       "source": "foundations-modality",
       "target": "actions-application-context-menu"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "qualities-agency"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "qualities-learnability"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "qualities-formality"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "activities-transparent-reasoning"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "activities-ai-tuning"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "actions-seeking-dynamic-hyperlinks"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "operations-reference"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "operations-deep-linking"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "foundations-information-architecture"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "actions-application-data-entry"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "operations-status-feedback"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "operations-toast"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "operations-callout"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "actions-coordination-notification"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "foundations-intent-interaction"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "foundations-collaboration"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "foundations-assistance"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "foundations-delegation"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "qualities-conversation"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "actions-sensemaking-explanation"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "actions-application-suggestion"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "activities-localization"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "activities-bot"
+    },
+    {
+      "source": "foundations-prose",
+      "target": "activities-generated-content"
     },
     {
       "source": "foundations-material-iconography",
@@ -3804,7 +3804,7 @@
     },
     {
       "source": "operations-reference",
-      "target": "foundations-content"
+      "target": "foundations-prose"
     },
     {
       "source": "operations-reference",
@@ -4285,10 +4285,6 @@
     {
       "source": "qualities-formality",
       "target": "actions-application-form"
-    },
-    {
-      "source": "qualities-formality",
-      "target": "foundations-content"
     },
     {
       "source": "qualities-formality",

--- a/src/stories/foundations/Data.mdx
+++ b/src/stories/foundations/Data.mdx
@@ -78,8 +78,7 @@ The design may support adjustable layering:
 - [Agency](../?path=/docs/qualities-agency--docs) — User control over data layer configuration
 - [Adaptability](../?path=/docs/qualities-adaptability--docs) — Soft layers enable probabilistic adaptation
 - [Conversation](../?path=/docs/qualities-conversation--docs) — Turn-taking between user input and system responses
-- [Information architecture](../?path=/docs/foundations-information-architecture--docs) — the structural counterpart of this foundation's certainty side. IA organises the surface (grouping, labelling systems, navigation); this foundation describes the certainty and provenance of what's organised. Entity-relationship thinking names the structural side; layered data architecture names the certainty side.
-- [Prose](../?path=/docs/foundations-prose--docs) — the surface where authored (explicit) and generated (inferred) layers visibly meet; register drift between them is the coherence failure across certainty layers.
+- [Information architecture](../?path=/docs/foundations-information-architecture--docs) — structural organisation determines how data layers are accessed and discovered
 
 ## Resources
 

--- a/src/stories/foundations/Data.mdx
+++ b/src/stories/foundations/Data.mdx
@@ -78,7 +78,8 @@ The design may support adjustable layering:
 - [Agency](../?path=/docs/qualities-agency--docs) — User control over data layer configuration
 - [Adaptability](../?path=/docs/qualities-adaptability--docs) — Soft layers enable probabilistic adaptation
 - [Conversation](../?path=/docs/qualities-conversation--docs) — Turn-taking between user input and system responses
-- [Information architecture](../?path=/docs/foundations-information-architecture--docs) — structural organization determines how data layers are accessed and discovered
+- [Information architecture](../?path=/docs/foundations-information-architecture--docs) — the structural counterpart of this foundation's certainty side. IA organises the surface (grouping, labelling systems, navigation); this foundation describes the certainty and provenance of what's organised. Entity-relationship thinking names the structural side; layered data architecture names the certainty side.
+- [Prose](../?path=/docs/foundations-prose--docs) — the surface where authored (explicit) and generated (inferred) layers visibly meet; register drift between them is the coherence failure across certainty layers.
 
 ## Resources
 

--- a/src/stories/foundations/InformationArchitecture.mdx
+++ b/src/stories/foundations/InformationArchitecture.mdx
@@ -69,7 +69,7 @@ Use hypertext structures when exploring conceptual connections matters more than
 Links can be structural (navigation through hierarchy), associative (related content, "see also"), temporal (previous/next, chronological).
 Multiple paths to the same content enable [exploring](../?path=/docs/foundations-intent-interaction--docs#exploring) and serendipitous discovery.
 [Dynamic hyperlinks](../?path=/docs/actions-seeking-dynamic-hyperlinks--docs) adapt based on context or actor behaviour.
-Beyond its structural role, the authored link carries a rhetorical register (See [Content § Link rhetoric](../?path=/docs/foundations-content--docs)).
+Beyond its structural role, the authored link carries a rhetorical register (see [Prose § Link rhetoric](../?path=/docs/foundations-prose--docs)).
 
 ### Social structures
 
@@ -99,6 +99,8 @@ The central tension is control versus flexibility.
 Labels must match actor mental models shaped by domain expertise, cultural context, and prior systems.
 Multilingual contexts complicate this—direct translation often fails when concepts don't map cleanly across languages.
 
+Label systems set what the vocabulary is; the choice of word within that system is a rhetorical move (see [Prose § Microcopy](../?path=/docs/foundations-prose--docs)).
+
 ## Related patterns
 
 - Structure of information shapes [agency distribution](../?path=/docs/qualities-agency--docs).
@@ -116,7 +118,7 @@ Multilingual contexts complicate this—direct translation often fails when conc
   - Common taxonomies create shared vocabulary
   - Controlled vocabularies reduce miscommunication
   - Social structures emerge from collective activity
-- [Data & information](../?path=/docs/foundations-data--information--docs) — metadata and relationships can have varying certainty and provenance
+- [Data & information](../?path=/docs/foundations-data--information--docs) — the certainty/provenance counterpart of IA's structural side. IA organises the surface (grouping, labelling systems, navigation); Data & Information describes the certainty of what's organised. Entity-relationship thinking (§ *Relational structures* above) names the structural side; layered data architecture names the certainty side. Folksonomies are explicit-but-unstable; algorithmic classification is inferred/probabilistic — the provenance axis runs through IA's vocabulary choices without being named there.
 - [Structure compositions](../?path=/docs/actions-navigation-overview--docs) — patterns that manifest structural choices
 - [Localization](../?path=/docs/activities-localization--docs) — adapts IA across locales
 

--- a/src/stories/foundations/InformationArchitecture.mdx
+++ b/src/stories/foundations/InformationArchitecture.mdx
@@ -99,8 +99,6 @@ The central tension is control versus flexibility.
 Labels must match actor mental models shaped by domain expertise, cultural context, and prior systems.
 Multilingual contexts complicate this—direct translation often fails when concepts don't map cleanly across languages.
 
-Label systems set what the vocabulary is; the choice of word within that system is a rhetorical move (see [Prose § Microcopy](../?path=/docs/foundations-prose--docs)).
-
 ## Related patterns
 
 - Structure of information shapes [agency distribution](../?path=/docs/qualities-agency--docs).
@@ -118,7 +116,7 @@ Label systems set what the vocabulary is; the choice of word within that system 
   - Common taxonomies create shared vocabulary
   - Controlled vocabularies reduce miscommunication
   - Social structures emerge from collective activity
-- [Data & information](../?path=/docs/foundations-data--information--docs) — the certainty/provenance counterpart of IA's structural side. IA organises the surface (grouping, labelling systems, navigation); Data & Information describes the certainty of what's organised. Entity-relationship thinking (§ *Relational structures* above) names the structural side; layered data architecture names the certainty side. Folksonomies are explicit-but-unstable; algorithmic classification is inferred/probabilistic — the provenance axis runs through IA's vocabulary choices without being named there.
+- [Data & information](../?path=/docs/foundations-data--information--docs) — metadata and relationships can have varying certainty and provenance
 - [Structure compositions](../?path=/docs/actions-navigation-overview--docs) — patterns that manifest structural choices
 - [Localization](../?path=/docs/activities-localization--docs) — adapts IA across locales
 

--- a/src/stories/foundations/Prose.mdx
+++ b/src/stories/foundations/Prose.mdx
@@ -78,7 +78,7 @@ The anchoring tension: *authored prose versus generated prose*. Most interfaces 
 ### Neighbouring foundations
 
 - [Information architecture](../?path=/docs/foundations-information-architecture--docs) — labelling as vocabulary structure; this foundation owns label-as-prose
-- [Data & Information](../?path=/docs/foundations-data--information--docs) — generated prose as a probabilistic/inferred layer; register drift as a coherence problem across certainty layers
+- [Data & Information](../?path=/docs/foundations-data--information--docs) — generated prose as a probabilistic/inferred layer
 - [Intent & interaction](../?path=/docs/foundations-intent-interaction--docs) — interaction as conversational alignment
 - [Collaboration](../?path=/docs/foundations-collaboration--docs) — prose as shared ground between participants
 - [Assistance](../?path=/docs/foundations-assistance--docs) — microcopy as assistive turns

--- a/src/stories/foundations/Prose.mdx
+++ b/src/stories/foundations/Prose.mdx
@@ -1,10 +1,10 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/Content" />
+<Meta title="Foundations/Prose" />
 
 > ✍️ **Fun meter: 4/5**. Text as design material.
 
-# Content
+# Prose
 
 The prose stratum of the interface — the words, phrasings, labels, and linking choices through which the system takes its turn in the conversation with the user.
 
@@ -78,6 +78,7 @@ The anchoring tension: *authored prose versus generated prose*. Most interfaces 
 ### Neighbouring foundations
 
 - [Information architecture](../?path=/docs/foundations-information-architecture--docs) — labelling as vocabulary structure; this foundation owns label-as-prose
+- [Data & Information](../?path=/docs/foundations-data--information--docs) — generated prose as a probabilistic/inferred layer; register drift as a coherence problem across certainty layers
 - [Intent & interaction](../?path=/docs/foundations-intent-interaction--docs) — interaction as conversational alignment
 - [Collaboration](../?path=/docs/foundations-collaboration--docs) — prose as shared ground between participants
 - [Assistance](../?path=/docs/foundations-assistance--docs) — microcopy as assistive turns

--- a/src/stories/foundations/Writing.md
+++ b/src/stories/foundations/Writing.md
@@ -1,1 +1,0 @@
-https://developer.apple.com/design/human-interface-guidelines/writing

--- a/src/stories/operations/Reference.mdx
+++ b/src/stories/operations/Reference.mdx
@@ -19,7 +19,7 @@ Surface a linked entity inline, letting the actor verify a connection without na
 
 ## Related patterns
 
-- [Content](../?path=/docs/foundations-content--docs) — link rhetoric and the authored-link counterpart of inline reference
+- [Prose](../?path=/docs/foundations-prose--docs) — link rhetoric and the authored-link counterpart of inline reference
 - [Dynamic hyperlinks](../?path=/docs/actions-seeking-dynamic-hyperlinks--docs) — the algorithmic (soft) counterpart to author-placed references
 - [Item view](../?path=/docs/actions-seeking-item-view--docs)
 - [Command menu](../?path=/docs/actions-seeking-command-menu--docs) for browsing available references


### PR DESCRIPTION
## Summary
Rename the "Content" foundation to "Prose" throughout the pattern system to better reflect the focus on prose as a design material (words, phrasings, labels, and linking choices) rather than generic content.

## Key Changes
- **Pattern graph updates** (`src/pattern-graph.json`):
  - Removed `foundations-content` node definition
  - Added `foundations-prose` node definition in alphabetical order
  - Updated all 28 graph connections from `foundations-content` to `foundations-prose`
  - Updated reverse connections pointing to the renamed foundation

- **Activity levels** (`src/activity-levels.json`):
  - Removed `foundations-content` entry
  - Added `foundations-prose` entry with identical metadata (cross-cutting, foundations category)

- **Documentation updates**:
  - Renamed `Content.mdx` to `Prose.mdx` with updated title and heading
  - Updated cross-references in related documents:
    - `InformationArchitecture.mdx`: Updated link to Prose § Link rhetoric
    - `Data.mdx`: Added connection to Prose as a layer for generated prose
    - `Reference.mdx`: Updated link rhetoric reference
  - Updated `docs/references.md` section header from "Content and rhetoric" to "Prose and rhetoric"

- **Removed**:
  - `src/stories/foundations/Writing.md` (external reference file)

## Implementation Details
The rename maintains all semantic relationships and connection patterns—no functional changes to the graph structure, only identifier and label updates. The new "Prose" terminology better aligns with the foundation's actual scope: the authored and generated language layer of the interface.

https://claude.ai/code/session_011AEgUeDWSiwUTGCvMrvKZP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized foundational documentation structure, renaming the Content foundation section to Prose with updated cross-references and navigation links throughout the documentation system.
  * Enhanced Prose foundation documentation with additional Data & Information context.

* **Chores**
  * Updated internal documentation framework references and patterns to align with the reorganized foundation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->