### PR TITLE
Clarify Storybook accessibility testing standards and expectations

### DIFF
--- a/docs/quality/testing-strategy.md
+++ b/docs/quality/testing-strategy.md
@@ -21,12 +21,14 @@ When writing or modifying Storybook stories, use `/example-skills:webapp-testing
 
 ## Storybook accessibility tests
 
-Storybook uses `@storybook/addon-a11y` with `@storybook/addon-vitest`.
-The global accessibility test behavior lives in `.storybook/preview.ts`:
+Storybook uses `@storybook/addon-a11y` with `@storybook/addon-vitest`. The global accessibility test behavior lives in `.storybook/preview.ts`.
 
-- `todo` keeps violations visible in Storybook's test UI without failing CI.
-- `error` turns violations into failing Storybook Vitest tests.
-- `off` should be reserved for stories that intentionally demonstrate non-accessible usage.
+Default to `error` for all stories — violations should fail Storybook Vitest tests. Deviations require explicit justification:
+
+- `todo` only with a linked issue tracking the fix.
+- `off` only with an inline comment explaining the intentional non-accessible usage.
+
+A passing axe run is a regression floor, not accessibility sign-off — interaction behaviour, contrast in hover/focus/dark-mode states, and focus management still need whatever verification the implementation plan specifies.
 
 Use `npm run test-storybook -- --run` for a one-shot local run. If Chromium is missing after installing or updating Playwright, run `npx playwright install chromium`.
 


### PR DESCRIPTION
## Summary
Updated the testing strategy documentation to establish clearer guidelines for Storybook accessibility testing with `@storybook/addon-a11y` and `@storybook/addon-vitest`.

## Key Changes
- **Established `error` as the default** for all stories, making accessibility violations fail Storybook Vitest tests by default
- **Added explicit justification requirements** for deviations:
  - `todo` violations now require a linked issue tracking the fix
  - `off` violations now require an inline comment explaining the intentional non-accessible usage
- **Clarified scope limitations** by documenting that axe test passes are a regression floor, not a complete accessibility sign-off
- **Added verification reminders** that interaction behavior, contrast in various states (hover/focus/dark-mode), and focus management still require implementation-plan-specified verification

## Implementation Details
The changes emphasize a shift toward stricter accessibility standards by default while allowing documented exceptions. This helps prevent accessibility regressions while being transparent about the limitations of automated axe testing and the need for additional manual verification.

https://claude.ai/code/session_019A3wYiykJdwPCeiaap6fcQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Storybook accessibility testing guidelines to clarify default behavior for accessibility violations and explain that passing accessibility tests serve as a baseline rather than comprehensive sign-off, with emphasis on continued manual verification of interactions, contrast, and focus management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->