### PR TITLE
Extract combobox primitives and document selection patterns

### DIFF
--- a/plans/active/2026-05-combobox-autocomplete.md
+++ b/plans/active/2026-05-combobox-autocomplete.md
@@ -1,0 +1,122 @@
+# Add a demo story to Autocomplete
+
+## Context
+
+`Autocomplete.mdx` therefore has no companion stories file. The user wants the Autocomplete page to show a working example "for the sake of completeness" — one demo that pulls its weight beyond the Combobox contract by illustrating an Autocomplete-specific design consideration.
+
+The mdx names two such considerations (`Autocomplete.mdx:18-19`):
+
+1. *Recent and frequent items often beat algorithmic suggestions, or at least deserve a spot alongside them.*
+2. *Worth distinguishing narrowing (filtering a known list) from expanding (proposing related or trending terms the actor hasn't thought of).*
+
+The chosen demo focus is consideration (1) — Recent + algorithmic. Combobox.Default already shows generic narrowing; layering a Recent group on top is what makes the demo recognisably Autocomplete-shaped rather than a thinner repeat of the contract page.
+
+## Approach
+
+Add one story file, wire it into the mdx, follow the same shape Combobox.mdx uses for its embedded story.
+
+### Files modified
+
+New:
+
+- `src/stories/operations/Autocomplete.stories.tsx`
+
+Edited:
+
+- `src/stories/operations/Autocomplete.mdx`
+
+### `Autocomplete.stories.tsx`
+
+Shape, mirroring `Combobox.stories.tsx`:
+
+- `meta.title = "Operations/Autocomplete"` (matches the current `<Meta title=…>` so the docs URL `operations-autocomplete--docs` and pattern-graph node id stay stable).
+- Imports the renamed primitives from `src/components/combobox` — `Combobox`, `ComboboxInput`, `ComboboxList`, `ComboboxEmpty`, `ComboboxGroup`, `ComboboxItem`. This is deliberate: `Autocomplete.mdx:25` (after this branch's edits) lists Combobox as the precursor, so the demo realises that relationship visibly.
+- One exported story: `Default`.
+
+Story logic for `Default`:
+
+- Local `query` state tracked via `onValueChange` on `ComboboxInput` — needed only to conditionally show/hide the Suggestions group when the input is empty. cmdk owns filtering via its built-in fuzzy scorer; the story does not pass `shouldFilter={false}`.
+- Two inline datasets (kept inside the file — no new JSON, since global-search-style query completion is a different shape from the entity-picker datasets in `src/stories/data/`):
+
+  ```
+  recentSearches: string[]   // ~4 items
+  popularSearches: string[]  // ~6–8 items
+  ```
+
+  Choose plausible domain queries (e.g. "Q1 sustainability report", "circular economy", "scope 3 emissions") so the demo reads as a knowledge-work search palette rather than a generic combobox.
+- Render structure:
+
+  ```
+  <Combobox>
+    <ComboboxInput onValueChange={setQuery} placeholder="Search…" />
+    <ComboboxList>
+      <ComboboxEmpty>No results.</ComboboxEmpty>
+      <ComboboxGroup heading="Recent">
+        {recentSearches.map(…)}
+      </ComboboxGroup>
+      {query && (
+        <ComboboxGroup heading="Suggestions">
+          {popularSearches.map(…)}
+        </ComboboxGroup>
+      )}
+    </ComboboxList>
+  </Combobox>
+  ```
+
+  So:
+  - Empty input shows the Recent group only — recents are useful before the actor types, not during.
+  - Non-empty input: Recent group is hidden (typing signals disinterest in recents); cmdk fuzzy-scores items in the Suggestions group.
+  - Each `ComboboxItem` uses `<iconify-icon icon="ph:clock-counter-clockwise" slot="prefix" />` for recents and `"ph:magnifying-glass"` for suggestions — matches the icon convention in `Combobox.stories.tsx:21-37`.
+  - `onSelect` writes the picked string back into the cmdk value (commits the completion) — illustrates "economy of typing" from `Autocomplete.profile.ts:7`.
+
+- Width wrapper `<div style={{ width: '320px' }}>` (matches Combobox.stories.tsx).
+
+Optional `parameters.docs.description.story` text on `Default` is fine but not required — the mdx body carries the framing.
+
+### `Autocomplete.mdx` edits
+
+Convert the Meta block from `title=`/tags-only to the `of=`/tags pair the new Combobox.mdx uses (`Combobox.mdx:1-6`):
+
+```
+import { Canvas, Story, Meta } from '@storybook/addon-docs/blocks';
+import * as AutocompleteStories from './Autocomplete.stories.tsx';
+import { profile } from './Autocomplete.profile';
+
+<Meta of={ AutocompleteStories } tags={['activity-level:operation', 'atomic:pattern', 'role:pattern', 'mediation:individual']} />
+```
+
+Note the role tag stays `role:pattern` — Autocomplete is a move/intent applied to the Combobox contract. The territory plan's role-tag invariant test (`2026-05-combobox-territory.md:112`) holds: Autocomplete prose is situation-and-forces-shaped (when to use it, what alternatives exist), not contract-shaped.
+
+Then add a Canvas block immediately after the one-sentence definition, in the position Combobox.mdx uses:
+
+```
+<Canvas>
+  <Story of={ AutocompleteStories.Default } />
+</Canvas>
+```
+
+Place it between `Autocomplete.mdx:12` (the definition sentence) and `Autocomplete.mdx:14` (the assisted-task-completion paragraph). The "Design considerations" heading on line 16 and everything below is unchanged.
+
+The `import { profile } from './Autocomplete.profile';` line on line 2 of the existing mdx already exists; keep it.
+
+## Critical files
+
+- `src/stories/operations/Autocomplete.mdx` — already on this branch with the Combobox precursor link added; needs Meta swap + Canvas insertion.
+- `src/stories/operations/Autocomplete.profile.ts` — read only; no changes. The `operates on / produces / enacts` triple frames the story and informs the dataset choice (free-form input where the valid-answer set is large).
+- `src/stories/operations/Combobox.stories.tsx` — direct structural template for the new file (icons, wrapper width, story shape).
+- `src/stories/operations/Combobox.mdx` — direct structural template for the Meta-and-Canvas wiring.
+- `src/components/combobox/index.ts` — exports the primitives the story imports.
+
+## Reused utilities
+
+- `src/components/combobox/` (`Combobox`, `ComboboxInput`, `ComboboxList`, `ComboboxEmpty`, `ComboboxGroup`, `ComboboxItem`) — the renamed primitives extracted by the territory work. No new component code.
+- `iconify-icon` web component + `src/jsx-types` registration — already used by Combobox.stories.tsx; reuse pattern verbatim.
+- `cmdk`'s `shouldFilter={false}` — the convention every existing combobox consumer in this repo uses (`Combobox.mdx:30`).
+
+## Verification
+
+- `npm run storybook` — open *Operations / Autocomplete*; the embedded Canvas renders the Default story; typing into the input narrows both groups; clearing the input restores the Recent-only view; activating an item commits its text into the input.
+- *Cross-link sweep*: from the Autocomplete page, clicking the Combobox precursor link lands on the Combobox docs page (URL `operations-combobox--docs`).
+- `npm run test` — ESLint clean across the new file.
+- *Pattern graph stability*: `src/pattern-graph.json` regeneration (whatever script the project uses; the territory plan refers to it as part of `Verification`) leaves the existing `operations-autocomplete` node and its seven edges intact. The Meta swap from `title=` to `of=` should not change the node id or the tag set — confirm by diffing the regenerated file.
+- *Role-tag invariant*: re-read `Autocomplete.mdx` after the edit. The story illustrates a move (the actor types, the system suggests, the actor commits); the prose still talks about when to use the move, not what its contract is. If the prose shifts toward contract semantics, that's a strain signal worth capturing in the territory plan's *Findings*; we don't expect it for this change.

--- a/plans/active/2026-05-combobox-primitives-extraction.md
+++ b/plans/active/2026-05-combobox-primitives-extraction.md
@@ -1,0 +1,127 @@
+---
+title: "Combobox primitives extraction"
+status: "active"
+kind: "exec-spec"
+created: "2026-05"
+last_reviewed: "2026-05-07"
+area: "components"
+promoted_to: ""
+superseded_by: ""
+---
+# Combobox primitives extraction
+
+A code refactor that extracts the combobox primitives currently living in `src/components/command-menu/command.tsx` into a sibling `src/components/combobox/` module, with identifiers renamed from `Command*` to `Combobox*`. Pure rename — no behaviour change, no new code, no shim. Sibling to [`2026-05-combobox-territory.md`](./2026-05-combobox-territory.md), which provides the documentation framing.
+
+## Context
+
+`src/components/command-menu/command.tsx` exposes thin React wrappers over [`cmdk`](https://www.npmjs.com/package/cmdk) (`package.json:81`) under names `Command`, `CommandInput`, `CommandList`, `CommandEmpty`, `CommandGroup`, `CommandItem`, `CommandItemPrefix`, `CommandItemSuffix`. Mechanically these are the WAI-ARIA APG combobox primitives — `cmdk` itself implements the combobox pattern under its "Command" branding.
+
+The `Command*` naming is **application-derived**, not mechanism-derived. The primitives are already used by multiple distinct moves:
+
+- `command-menu/command-menu.tsx` — Command menu pattern (the original consumer)
+- `reference/ReferencePicker.tsx` — reference picker (combobox over reference items)
+- `filter/filter-components.tsx` — Filter value pickers
+- `filter/index.ts` — re-exports the same primitives downstream
+- 4 story files under `src/stories/actions/seeking/` — story-side composition
+
+This refactor renames the primitives to reflect what they actually are. The rename earns its keep because:
+
+1. Multiple non-command-menu consumers already exist — the misnaming is a real friction (a reference picker importing from `command-menu/command` reads as a categorical mistake to a new reader).
+2. The companion documentation plan (`2026-05-combobox-territory.md`) authors a `Combobox.mdx` that names the contract; the code-side identifier should match.
+3. Per `pattern-definition.md` and `2026-05-role-metadata.md`, the project's framing is that **combobox is the substrate, command menu is one move that composes it**. The directory layout should make that legible.
+
+Per project style (`AGENTS.md`, `state-management.md`), no backwards-compatibility shim — drop `Command*` re-exports and update all consumers in one pass.
+
+## Scope
+
+Pure rename. No behaviour change. The `CommandMenu` React component, the `command-menu/hooks/`, `command-menu/adapters/`, and the data types in `command-menu-types.ts` (`CommandData`, `CommandChildData`, `CommandItem`-the-type, `RecentItem`) all retain their names — they are command-menu-specific, not combobox primitives.
+
+**Side effect (worth noting, not a separate change)**: `CommandItem` currently means two things — the primitive React component (`command.tsx`) and the data-type union (`command-menu-types.ts`). After the rename, `CommandItem` unambiguously means the data type.
+
+### Identifier rename map
+
+| Old (in `command-menu/command.tsx`) | New (in `combobox/combobox.tsx`) |
+|---|---|
+| `Command` | `Combobox` |
+| `CommandInput` | `ComboboxInput` |
+| `CommandList` | `ComboboxList` |
+| `CommandEmpty` | `ComboboxEmpty` |
+| `CommandGroup` | `ComboboxGroup` |
+| `CommandItem` (component) | `ComboboxItem` |
+| `CommandItemPrefix` | `ComboboxItemPrefix` |
+| `CommandItemSuffix` | `ComboboxItemSuffix` |
+| `CommandProps` | `ComboboxProps` |
+| `CommandInputProps` | `ComboboxInputProps` |
+| `CommandItemProps` | `ComboboxItemProps` |
+| `CommandItemPrefixProps` | `ComboboxItemPrefixProps` |
+| `CommandItemSuffixProps` | `ComboboxItemSuffixProps` |
+| `SlotProps`, `CommandItemSlots`, `useCommandItemSlots` | `SlotProps`, `ComboboxItemSlots`, `useComboboxItemSlots` |
+
+The `import { Command as CommandPrimitive } from "cmdk"` line stays — `cmdk`'s exports keep their names; only the project's wrapper names change. The internal alias becomes `import { Command as ComboboxPrimitive } from "cmdk"` for consistency.
+
+## Files
+
+### New
+
+- `src/components/combobox/combobox.tsx` — primitives, moved verbatim from `command-menu/command.tsx` with the rename map applied. No structural changes to JSX or hook bodies.
+- `src/components/combobox/index.ts` — re-exports the primitives.
+
+### Deleted
+
+- `src/components/command-menu/command.tsx` — content moved to `combobox/combobox.tsx`. Per project style, no shim left behind.
+
+### Edited
+
+- `src/components/command-menu/command-menu.tsx` — change import from `./command` to `../combobox`, rename identifiers.
+- `src/components/command-menu/ai-fallback-handler.tsx` — change import from `./command` to `../combobox`, rename identifiers.
+- `src/components/command-menu/index.ts` — drop the `Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem, CommandItemPrefix, CommandItemSuffix` re-exports. Keep `CommandMenu`, `AIFallbackHandler`, hooks, AI types, data types.
+- `src/components/reference/ReferencePicker.tsx` — change import from `../command-menu/command` to `../combobox`, rename identifiers in JSX.
+- `src/components/filter/index.ts` — drop the `Command*` re-exports (lines 22-32 region). Consumers import from `combobox/` directly.
+- `src/components/filter/filter-components.tsx` — change import from `../command-menu/command` to `../combobox`, rename identifiers in JSX.
+- `src/stories/actions/seeking/CommandMenu.tsx` — change imports, rename identifiers.
+- `src/stories/actions/seeking/Filtering.tsx` — change imports, rename identifiers.
+- `src/stories/actions/seeking/DataView/FilterControls.tsx` — change imports, rename identifiers.
+- `src/stories/actions/seeking/DataView/ProductFilterValueDropdown.tsx` — change imports, rename identifiers.
+
+### Not modified
+
+- `src/components/command-menu/command-menu-types.ts` — data types stay; they are command-menu-specific.
+- `src/components/command-menu/hooks/**` — command-menu-specific compositions.
+- `src/components/command-menu/adapters/**` — same.
+- `src/components/component-registry.ts`, `src/components/register-all.ts` — these are for Lit `pp-*` web components; React components are unaffected.
+- `src/stories/actions/seeking/DataView/aiFilterAdapter.ts` — type imports only (`AICommandResult`, `AICommandItem`); these are AI-command types, not combobox primitives, and stay in `command-menu/`.
+
+## Verification
+
+- `npm run test` — ESLint clean.
+- `tsc --noEmit` (or whatever the typecheck command is in `docs/quality/testing-strategy.md`) — no type errors. The renames are pure identifier moves so the type graph should be unchanged.
+- `npm run storybook` — load the affected stories and confirm rendering:
+  - `Actions/Seeking/Command Menu` — primary command-menu story
+  - `Actions/Seeking/Filtering` — filter value picker
+  - `Actions/Seeking/Data View / *` — filter controls and product filter dropdown
+  - `Operations/Reference` (if exists) — reference picker
+- *Grep invariant* — after the change, `grep -r "from.*command-menu/command['\"]" src/` should return zero results, and `grep -rE "\\b(Command|CommandInput|CommandList|CommandEmpty|CommandGroup|CommandItem|CommandItemPrefix|CommandItemSuffix)\\b" src/` should match only data-type uses (`CommandData`, etc.) plus the type union from `command-menu-types.ts` named `CommandItem`. The primitive identifiers should appear nowhere outside `combobox/` and the `cmdk` import alias.
+
+## Risks
+
+- *Name clash on `CommandItem`*: the data-type `CommandItem` in `command-menu-types.ts:68` shadows the primitive component name. After rename this clash dissolves — `CommandItem` unambiguously means the data type.
+- *Story breakage*: 4 story files touch the primitives. The rename is mechanical but easy to miscount. Verify each story renders.
+- *External consumers of `filter/index.ts` re-exports*: dropping the re-exports from `filter/index.ts` may break files that imported `Command*` from `filter/`. The grep above will catch these. Update them to import from `combobox/`.
+- *Future `pp-combobox` (Lit)*: out of scope. If a Lit-side composition ever needs combobox semantics, it can land later as `src/components/combobox/pp-combobox.ts` alongside the React primitives. The directory naming is friendly to both. Per `2026-05-combobox-territory.md`, no current consumer demands it.
+
+## Phase ordering
+
+Single phase. All changes ship together or not at all — leaving the rename half-done would break imports.
+
+## Coordination with `2026-05-combobox-territory.md`
+
+The territory plan's `Combobox.mdx` documentation page references the new `combobox/` location. Two ship orders work:
+
+- *Refactor first* (preferred). Land this plan, then author `Combobox.mdx` against the new location with no follow-up edits needed.
+- *Docs first, refactor follows*. `Combobox.mdx` initially names `command-menu/command.tsx` as the realisation; this plan lands later and the docs are updated in the same commit.
+
+The refactor is independently revertible from the docs. The docs are not independently revertible from the refactor (the docs would name a non-existent location).
+
+## Findings
+
+(populate during execution — capture any unexpected coupling, name clashes, or missed consumers)

--- a/plans/active/2026-05-combobox-territory.md
+++ b/plans/active/2026-05-combobox-territory.md
@@ -1,0 +1,138 @@
+---
+title: "Combobox and adjacent surfaces"
+status: "active"
+kind: "exec-spec"
+created: "2026-05"
+last_reviewed: "2026-05-07"
+area: "patterns"
+promoted_to: ""
+superseded_by: ""
+---
+# Combobox and adjacent surfaces
+
+A plan to land Combobox as a `role:component` page, extend `Selection.mdx` with a multi-cardinality treatment and example stories, and add a Dual listbox placeholder so the article's territory is mapped without flattening the project's intent-based slicing of moves (Autocomplete, Command menu, Filtering, Searching, Select).
+
+## Context
+
+Smashing Magazine's *[Combobox vs Multiselect vs Listbox](https://www.smashingmagazine.com/2026/02/combobox-vs-multiselect-vs-listbox/)* organises five list-selection surfaces by widget shape (option count × default visibility). The project already covers most of this territory by **intent**, in `Autocomplete`, `Command menu`, `Filtering`, `Searching`, `Selection`, `Select`, `Dropdown`, and `List`. The article's framing collapses what the project deliberately keeps separate.
+
+The conversation-level decision is to treat the article as one input, not a canonical decomposition:
+
+- *Combobox* lands as `role:component` — the contract-bearing mechanism that Autocomplete, Command menu, Filtering, and a future searchable Select all compose with. It is the prototype case named in [`2026-05-role-metadata.md`](./2026-05-role-metadata.md) Open Question 1 ("is `role:control` a needed third role?"). The combobox page is a useful empirical case for that question — its prose may strain the `role:component` reading. Capture the strain if it appears; do not pre-emptively introduce `role:control`.
+- *Multiselect* is absorbed into [`Selection.mdx`](../../src/stories/actions/coordination/Selection.mdx) as a cardinality + visibility variant. Rather than fork a new page that would compete with Selection's already richer treatment of persistence, "select all visible vs. matching", and selection-as-imperative-filter duality.
+- *Listbox-as-exhaustive-visibility* is deferred. The article's "all options visible" can also be radios or checkboxes, and overlaps with [`Modality.mdx`](../../src/stories/foundations/Modality.mdx)'s framing. No action this round; leave a note for a future pass.
+- *Dual listbox* gets a placeholder so the territory map is complete and Selection / ActionBar can cross-link to it. No story, no full pattern doc — a stub with the situation, the forces, and a TODO marker.
+
+## Scope
+
+### A. Combobox component page
+
+New files under `src/stories/operations/`:
+
+- `Combobox.mdx` — `role:component`, `atomic:pattern`, `mediation:individual`. Frame combobox as the WAI-ARIA APG control (text input + popup listbox + selection commit + keyboard model). Cite [APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). Explicitly position it as the mechanism Autocomplete (predicting), Command menu (invoking), Filtering value pickers (narrowing), Searching (retrieving), and a future searchable Select compose with. Note that the page documents a contract, not a move — the situation lives next door.
+- `Combobox.profile.ts` — generative profile in the format of [`Select.profile.ts`](../../src/stories/operations/Select.profile.ts). Operates on: a single value drawn from a long or unfamiliar option set. Produces: a typing surface that narrows candidates as the actor types. Enacts: recognition over recall, economy of typing, discoverability of options.
+- `Combobox.stories.tsx` — at minimum a Default story illustrating the contract; other stories at the author's discretion.
+
+Cross-links to add:
+
+- `Select.mdx:68` — replace "a future combobox" with a real link.
+- `Autocomplete.mdx` — note that combobox is the underlying contract.
+- `CommandMenu.mdx` — note that combobox is the underlying contract.
+- `Filtering.mdx` — note that combobox is the value-picker substrate.
+- `Searching.mdx` — note combobox in the entry/query phase.
+
+**Open question (capture, do not pre-resolve)**: does Combobox earn a `pp-combobox` web component, or is the page a documented contract over existing primitives (Input + Popup + List)? The page can launch with the *documented contract* shape; authoring the web component is its own follow-up plan if and when a story needs it. Per `web-components.md`, a real `pp-combobox` carries the bulletproof loading pattern, central registration, and event lifecycle obligations — non-trivial scope. Defer until a concrete demand surfaces.
+
+### B. Selection multi-select extension
+
+Edit and add:
+
+- [`Selection.mdx`](../../src/stories/actions/coordination/Selection.mdx) — extend the *Multi-selection* and *Visibility and discoverability* sections with the article's distinctions: chip rendering as ambient feedback, "Select All / Clear All" affordance threshold, the "select all visible vs. all matching" follow-up affordance (already present — sharpen rather than duplicate). Cross-link to the new Combobox page where the multi-cardinality combobox variant is the substrate.
+- New `Selection.stories.tsx` (currently absent) — example stories that render multi-select using `pp-list` with `multiselectable` (`src/components/list/list.ts:26`) and `pp-list-item` with checkbox affordance. Cover at least: inline always-visible checkboxes, mode-based reveal, and a "Select all visible / all 1,234" follow-up affordance. The mock-data convention in `.claude/rules/mock-data.md` applies.
+- `Selection.mdx` Meta — add `<Meta of={SelectionStories} />` once the stories file exists, to wire the docs page to the stories.
+
+### C. Dual listbox placeholder
+
+New file:
+
+- `src/stories/actions/coordination/DualListbox.mdx` — short stub. `role:pattern`, `atomic:pattern`. Frame the situation (committing a bulk assignment with side-by-side review of source and selection before applying), the forces (commitment scale, error cost, reviewability), the alternatives (inline multiselect when commitment is cheap; transfer list when it is consequential). Mark it explicitly as a seed — no canonical example yet. Add a TODO calling for a project example that motivates a full treatment.
+
+Cross-links to add:
+
+- `Selection.mdx` — list Dual listbox in *Adjacent to* or *Containers*, framed as "the staged-commit variant".
+- `ActionBar.mdx` — note dual listbox as an alternative when the action set is "assign these to that".
+- `plans/tech-debt-tracker.md` — add an entry "Dual listbox seeds an example" so the placeholder doesn't drift.
+
+### D. Listbox / exhaustive visibility — deferred
+
+No action this round. The article's *listbox = always visible options* conflates the ARIA listbox role (a popup primitive used inside combobox) with the design choice of exhaustive visibility, which can equally be radios or checkboxes. The Form decision tree's option-count branch (`docs/language/decision-dimensions.md`) and `Modality.mdx` partly cover it. Capture as a follow-up open question rather than an action item.
+
+## Files modified
+
+New:
+- `src/stories/operations/Combobox.mdx`
+- `src/stories/operations/Combobox.profile.ts`
+- `src/stories/operations/Combobox.stories.tsx`
+- `src/stories/actions/coordination/Selection.stories.tsx`
+- `src/stories/actions/coordination/DualListbox.mdx`
+
+Edited:
+- `src/stories/operations/Select.mdx` — replace "future combobox" with a live link
+- `src/stories/operations/Autocomplete.mdx` — note combobox as substrate
+- `src/stories/actions/seeking/CommandMenu.mdx` — note combobox as substrate
+- `src/stories/actions/seeking/Filtering.mdx` — note combobox as substrate
+- `src/stories/actions/seeking/Searching.mdx` — note combobox in entry phase
+- `src/stories/actions/coordination/Selection.mdx` — multi-select extension + stories Meta + DualListbox cross-link
+- `src/stories/actions/coordination/ActionBar.mdx` — DualListbox cross-link
+- `plans/tech-debt-tracker.md` — DualListbox seed entry
+- `src/pattern-graph.json` — regenerated by extraction once Meta tags are added
+
+Out of scope:
+- `pp-combobox` web component (deferred)
+- Listbox-as-exhaustive-visibility pattern page (deferred)
+- Decision-dimension extension to the Form tree (deferred)
+
+## Reused utilities
+
+- `pp-list` with `multiselectable` (`src/components/list/list.ts`) — substrate for Selection multi-select stories
+- `pp-list-item` with checkbox/radio types (`src/components/list-item/list-item.ts`) — option rendering
+- `pp-input` (`src/components/input/input.ts`) — combobox text-entry
+- `pp-popup` (`src/components/popup/`) — combobox popup positioning
+- The React `command-menu` (`src/components/command-menu/`) — exists as a working combobox-shaped surface; reference in Combobox.mdx as an example of the contract being satisfied today
+- The React `filter` value pickers (`src/components/filter/`) — another combobox-shaped surface to reference
+
+## Verification
+
+- `npm run storybook` — Combobox, Selection (with new stories), DualListbox pages render, cross-links resolve.
+- `npm run test` — ESLint clean across new files.
+- *Manual sweep*: open each cross-linked page and confirm the link goes the right direction (no dangling `--docs` URLs). Storybook URL rule is in `.claude/rules/documentation.md`.
+- *Pattern graph*: `src/pattern-graph.json` regenerates with new nodes for `operations-combobox` and `actions-coordination-dual-listbox`. Confirm `role:component` is present on Combobox; `role:pattern` on DualListbox; Selection unchanged.
+- *Role-tag invariant*: Combobox page reads as a contract / mechanism, not a move. If the prose pulls toward situation/forces/consequences, that is the strain signal for `2026-05-role-metadata.md` Open Question 1 — capture the cases in this plan's *Findings* section before promoting them into the role plan.
+
+## Findings
+
+(populate during execution)
+
+## Open questions
+
+1. *Does authoring the Combobox page surface a strain in `role:component`?* The role-metadata plan's Open Question 1 uses combobox as its test case. Capture any sentence in `Combobox.mdx` where the natural framing pulls toward "situation / forces / consequences" rather than "API / contract / states". If the strain is more than a footnote, that is the empirical signal for `role:control`.
+
+2. *Should `pp-combobox` be authored?* Out of scope for this plan; reopen if a story or example needs a real composed control rather than a documented contract. Likely candidates: a searchable Select demo, a filter value picker demo with async options, a `command-menu` migration if the React implementation is ever ported to web components.
+
+3. *Listbox-as-exhaustive-visibility — pattern, decision-dimension, or Modality extension?* Three coherent answers; no current pressure. Revisit when `Modality.mdx` is next edited or when the Form decision tree gets its next pass.
+
+4. *Does `Selection.stories.tsx` belong as one file with multiple stories, or split into Multi-select and Range stories?* Default to one file; split only if the file outgrows ~300 lines or the cardinalities diverge enough to confuse readers.
+
+## Phase ordering
+
+```
+A. Combobox component page (atomic; can ship alone)
+   │
+   ▼
+B. Selection extension + stories (depends on A for combobox cross-link)
+   │
+   ▼
+C. Dual listbox placeholder (depends on B for Selection cross-link)
+```
+
+A and C can ship in parallel if needed; B is the integrator. Each phase is independently revertible.

--- a/plans/active/2026-05-combobox-territory.md
+++ b/plans/active/2026-05-combobox-territory.md
@@ -18,7 +18,7 @@ Smashing Magazine's *[Combobox vs Multiselect vs Listbox](https://www.smashingma
 
 The conversation-level decision is to treat the article as one input, not a canonical decomposition:
 
-- *Combobox* lands as `role:component` — the contract-bearing mechanism that Autocomplete, Command menu, Filtering, and a future searchable Select all compose with. It is the prototype case named in [`2026-05-role-metadata.md`](./2026-05-role-metadata.md) Open Question 1 ("is `role:control` a needed third role?"). The combobox page is a useful empirical case for that question — its prose may strain the `role:component` reading. Capture the strain if it appears; do not pre-emptively introduce `role:control`.
+- *Combobox* lands as `role:component` — the contract-bearing mechanism that Autocomplete, Command menu, Filtering, Searching, and a future searchable Select all compose with. The mechanism is **already realised** in this codebase: `cmdk` (`package.json:81`) implements the WAI-ARIA combobox pattern, and `src/components/command-menu/command.tsx` exposes thin wrappers under `Command*` names. The companion plan [`2026-05-combobox-primitives-extraction.md`](./2026-05-combobox-primitives-extraction.md) renames those primitives to `Combobox*` under `src/components/combobox/`, after which `Combobox.mdx` documents the contract that the renamed primitives realise. The Combobox case decomposes cleanly under the existing role binary — see *Findings* — so [`2026-05-role-metadata.md`](./2026-05-role-metadata.md) Open Question 1 about `role:control` likely doesn't need to be promoted.
 - *Multiselect* is absorbed into [`Selection.mdx`](../../src/stories/actions/coordination/Selection.mdx) as a cardinality + visibility variant. Rather than fork a new page that would compete with Selection's already richer treatment of persistence, "select all visible vs. matching", and selection-as-imperative-filter duality.
 - *Listbox-as-exhaustive-visibility* is deferred. The article's "all options visible" can also be radios or checkboxes, and overlaps with [`Modality.mdx`](../../src/stories/foundations/Modality.mdx)'s framing. No action this round; leave a note for a future pass.
 - *Dual listbox* gets a placeholder so the territory map is complete and Selection / ActionBar can cross-link to it. No story, no full pattern doc — a stub with the situation, the forces, and a TODO marker.
@@ -29,19 +29,19 @@ The conversation-level decision is to treat the article as one input, not a cano
 
 New files under `src/stories/operations/`:
 
-- `Combobox.mdx` — `role:component`, `atomic:pattern`, `mediation:individual`. Frame combobox as the WAI-ARIA APG control (text input + popup listbox + selection commit + keyboard model). Cite [APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). Explicitly position it as the mechanism Autocomplete (predicting), Command menu (invoking), Filtering value pickers (narrowing), Searching (retrieving), and a future searchable Select compose with. Note that the page documents a contract, not a move — the situation lives next door.
+- `Combobox.mdx` — `role:component`, `atomic:pattern`, `mediation:individual`. Frame combobox as the WAI-ARIA APG control (text input + popup listbox + selection commit + keyboard model). Cite [APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) and [`cmdk`](https://www.npmjs.com/package/cmdk). Name `src/components/combobox/` (post-refactor) as the realisation. Explicitly position the contract as the mechanism Autocomplete (predicting), Command menu (invoking), Filtering value pickers (narrowing), Searching (retrieving), Reference picker (lookup), and a future searchable Select compose with. The page documents a contract, not a move — the situation lives next door in each consuming pattern.
 - `Combobox.profile.ts` — generative profile in the format of [`Select.profile.ts`](../../src/stories/operations/Select.profile.ts). Operates on: a single value drawn from a long or unfamiliar option set. Produces: a typing surface that narrows candidates as the actor types. Enacts: recognition over recall, economy of typing, discoverability of options.
-- `Combobox.stories.tsx` — at minimum a Default story illustrating the contract; other stories at the author's discretion.
+- `Combobox.stories.tsx` — at minimum a Default story illustrating the contract using the renamed `Combobox*` primitives; other stories at the author's discretion.
 
 Cross-links to add:
 
 - `Select.mdx:68` — replace "a future combobox" with a real link.
 - `Autocomplete.mdx` — note that combobox is the underlying contract.
-- `CommandMenu.mdx` — note that combobox is the underlying contract.
+- `CommandMenu.mdx` — note that combobox is the underlying contract; the command-menu primitives `Command*` were renamed to `Combobox*` in the extraction refactor.
 - `Filtering.mdx` — note that combobox is the value-picker substrate.
 - `Searching.mdx` — note combobox in the entry/query phase.
 
-**Open question (capture, do not pre-resolve)**: does Combobox earn a `pp-combobox` web component, or is the page a documented contract over existing primitives (Input + Popup + List)? The page can launch with the *documented contract* shape; authoring the web component is its own follow-up plan if and when a story needs it. Per `web-components.md`, a real `pp-combobox` carries the bulletproof loading pattern, central registration, and event lifecycle obligations — non-trivial scope. Defer until a concrete demand surfaces.
+**`pp-combobox` (Lit web component) — out of scope.** Initial framing kept this as an open question. After tracing the consumers (`reference/ReferencePicker.tsx`, `filter/filter-components.tsx`, `command-menu.tsx`, plus stories), every current need is satisfied by the React combobox primitives `cmdk` provides. Lit-side primitives (`pp-list`, `pp-input`, `pp-popup`) cover the simpler cases without needing a composed `pp-combobox`. Reopen only when a Lit-side composition demands combobox semantics (none currently does). The directory naming chosen by the extraction plan (`src/components/combobox/`) is friendly to a future `pp-combobox.ts` sibling if that day comes.
 
 ### B. Selection multi-select extension
 
@@ -96,10 +96,12 @@ Out of scope:
 
 - `pp-list` with `multiselectable` (`src/components/list/list.ts`) — substrate for Selection multi-select stories
 - `pp-list-item` with checkbox/radio types (`src/components/list-item/list-item.ts`) — option rendering
-- `pp-input` (`src/components/input/input.ts`) — combobox text-entry
-- `pp-popup` (`src/components/popup/`) — combobox popup positioning
-- The React `command-menu` (`src/components/command-menu/`) — exists as a working combobox-shaped surface; reference in Combobox.mdx as an example of the contract being satisfied today
-- The React `filter` value pickers (`src/components/filter/`) — another combobox-shaped surface to reference
+- `pp-input` (`src/components/input/input.ts`) — minor combobox primitive on the Lit side (not a current consumer)
+- `pp-popup` (`src/components/popup/`) — minor combobox primitive on the Lit side (not a current consumer)
+- The React combobox primitives at `src/components/combobox/` (post-refactor) — the realisation Combobox.mdx documents
+- `command-menu/CommandMenu` (`src/components/command-menu/command-menu.tsx`) — Command menu pattern's React composition over the combobox primitives
+- `filter/FilterValueDropdown` and friends (`src/components/filter/filter-components.tsx`) — filter value pickers as a second combobox consumer
+- `reference/ReferencePicker` (`src/components/reference/ReferencePicker.tsx`) — reference picker as a third combobox consumer; useful prior art for the searchable-Select pattern
 
 ## Verification
 
@@ -111,22 +113,21 @@ Out of scope:
 
 ## Findings
 
-(populate during execution)
+- *The `role:component` reading holds for Combobox.* Tracing the existing consumers (`command-menu`, `filter`, `reference/ReferencePicker`) shows three distinct moves — invoke a command, narrow a filter, look up a reference — composing the same primitive. The page's natural prose is "what the contract is" (semantics, keyboard, focus, popup positioning, narrowing behaviour); the situation belongs to each consumer. Open Question 1 in [`2026-05-role-metadata.md`](./2026-05-role-metadata.md) about whether `role:control` deserves to exist can be answered **no, not on this case** — combobox decomposes cleanly under the existing component/pattern binary.
 
 ## Open questions
 
-1. *Does authoring the Combobox page surface a strain in `role:component`?* The role-metadata plan's Open Question 1 uses combobox as its test case. Capture any sentence in `Combobox.mdx` where the natural framing pulls toward "situation / forces / consequences" rather than "API / contract / states". If the strain is more than a footnote, that is the empirical signal for `role:control`.
+1. *Listbox-as-exhaustive-visibility — pattern, decision-dimension, or Modality extension?* Three coherent answers; no current pressure. Revisit when `Modality.mdx` is next edited or when the Form decision tree gets its next pass.
 
-2. *Should `pp-combobox` be authored?* Out of scope for this plan; reopen if a story or example needs a real composed control rather than a documented contract. Likely candidates: a searchable Select demo, a filter value picker demo with async options, a `command-menu` migration if the React implementation is ever ported to web components.
-
-3. *Listbox-as-exhaustive-visibility — pattern, decision-dimension, or Modality extension?* Three coherent answers; no current pressure. Revisit when `Modality.mdx` is next edited or when the Form decision tree gets its next pass.
-
-4. *Does `Selection.stories.tsx` belong as one file with multiple stories, or split into Multi-select and Range stories?* Default to one file; split only if the file outgrows ~300 lines or the cardinalities diverge enough to confuse readers.
+2. *Does `Selection.stories.tsx` belong as one file with multiple stories, or split into Multi-select and Range stories?* Default to one file; split only if the file outgrows ~300 lines or the cardinalities diverge enough to confuse readers.
 
 ## Phase ordering
 
 ```
-A. Combobox component page (atomic; can ship alone)
+0. Combobox primitives extraction (separate plan: 2026-05-combobox-primitives-extraction.md)
+   │
+   ▼
+A. Combobox component page (depends on 0 for the path/identifiers it documents)
    │
    ▼
 B. Selection extension + stories (depends on A for combobox cross-link)
@@ -135,4 +136,4 @@ B. Selection extension + stories (depends on A for combobox cross-link)
 C. Dual listbox placeholder (depends on B for Selection cross-link)
 ```
 
-A and C can ship in parallel if needed; B is the integrator. Each phase is independently revertible.
+The extraction refactor is the gate. A, B, C are this plan's phases; each is independently revertible. A and C can ship in parallel after the refactor lands.

--- a/plans/index.md
+++ b/plans/index.md
@@ -5,6 +5,8 @@ the plan contract and `docs/specs/` for settled specifications.
 
 ## Active
 
+- [Combobox and adjacent surfaces](active/2026-05-combobox-territory.md) — pattern-language work for Combobox, Selection multi-select, Dual listbox placeholder
+- [Combobox primitives extraction](active/2026-05-combobox-primitives-extraction.md) — rename Command* React primitives to Combobox* under src/components/combobox/
 - [Role metadata](active/2026-05-role-metadata.md) — introduce role tags for component/pattern/umbrella distinctions
 - [Harness refactor](active/2026-04-harness.md) — control layer repair, enforcement, and drift detection
 - [Assistance foundation](active/2026-04-assistance-foundation.md) — ground assistance in agency theory

--- a/plans/tech-debt-tracker.md
+++ b/plans/tech-debt-tracker.md
@@ -11,6 +11,7 @@ Known rough edges. One line per item, linked to a plan or file where relevant.
 - *`no-explicit-any` eslint-disable in 5 files* — `Reference.tsx` (Tiptap types), `dropdown.ts` (event handling), `useDragToCreate.ts`, `nodeTypes.tsx`, `NodeShapeUtil.tsx` (tldraw types). Added 2026-04-12 during harness refactor ESLint enforcement.
 - *`no-unused-vars` pre-existing errors (36)* — scattered across tldraw, components, and services. Not introduced by harness refactor. See `npm run test` output.
 - *2 inline `style` prop eslint-disables* — `CommentComposer.tsx` (flex layout), `OnCanvasComponentPicker.tsx` (dynamic width). Added 2026-04-12.
+- *Dual listbox needs a project example* — `src/stories/actions/coordination/DualListbox.mdx` is a seed stub. Add a motivating example (e.g. "assign labels to tasks" bulk dialog, or "grant roles to users" screen) when the use case surfaces. TODO is marked in the file.
 
 ## Resolved
 

--- a/src/activity-levels.json
+++ b/src/activity-levels.json
@@ -133,6 +133,12 @@
       "atomic-category": "component",
       "mediation": "coordination"
     },
+    "actions-coordination-dual-listbox": {
+      "activity-level": "action",
+      "lifecycle-stage": "coordination",
+      "atomic-category": "pattern",
+      "mediation": "coordination"
+    },
     "actions-coordination-messaging": {
       "activity-level": "action",
       "lifecycle-stage": "coordination",
@@ -563,6 +569,12 @@
       "activity-level": "operation",
       "lifecycle-stage": null,
       "atomic-category": "primitive",
+      "mediation": "individual"
+    },
+    "operations-combobox": {
+      "activity-level": "operation",
+      "lifecycle-stage": null,
+      "atomic-category": "pattern",
       "mediation": "individual"
     },
     "operations-deep-linking": {

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Command as CommandPrimitive } from "cmdk"
+import { Command as ComboboxPrimitive } from "cmdk"
 import { Icon } from '@iconify/react'
 import { Slot } from "@radix-ui/react-slot"
 
@@ -10,13 +10,13 @@ interface SlotProps {
   children?: React.ReactNode;
 }
 
-interface CommandItemSlots {
+interface ComboboxItemSlots {
   prefix: React.ReactNode[];
   suffix: React.ReactNode[];
   content: React.ReactNode[];
 }
 
-const useCommandItemSlots = (children: React.ReactNode): CommandItemSlots => {
+const useComboboxItemSlots = (children: React.ReactNode): ComboboxItemSlots => {
   return React.useMemo(() => {
     const childArray = React.Children.toArray(children);
 
@@ -34,14 +34,14 @@ const useCommandItemSlots = (children: React.ReactNode): CommandItemSlots => {
   }, [children]);
 };
 
-interface CommandProps extends React.ComponentPropsWithoutRef<typeof CommandPrimitive> {
+interface ComboboxProps extends React.ComponentPropsWithoutRef<typeof ComboboxPrimitive> {
   /** Callback fired when the Escape key is pressed. Return true to prevent default behavior. */
   onEscape?: () => boolean | void;
 }
 
-const Command = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive>,
-  CommandProps
+const Combobox = React.forwardRef<
+  React.ElementRef<typeof ComboboxPrimitive>,
+  ComboboxProps
 >(({ onEscape, onKeyDown, ...props }, ref) => {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Escape' && onEscape) {
@@ -55,26 +55,26 @@ const Command = React.forwardRef<
   };
 
   return (
-    <CommandPrimitive
+    <ComboboxPrimitive
       ref={ref}
       onKeyDown={handleKeyDown}
       {...props}
     />
   )
 })
-Command.displayName = CommandPrimitive.displayName
+Combobox.displayName = ComboboxPrimitive.displayName
 
-interface CommandInputProps extends React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> {
+interface ComboboxInputProps extends React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Input> {
   placeholder?: string;
 }
 
-const CommandInput = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Input>,
-  CommandInputProps
+const ComboboxInput = React.forwardRef<
+  React.ElementRef<typeof ComboboxPrimitive.Input>,
+  ComboboxInputProps
 >(({ placeholder = "Search, commands, etc.", ...props }, ref) => (
   <div cmdk-input-wrapper="">
     <Icon icon="ph:magnifying-glass" className="icon" aria-hidden="true" />
-    <CommandPrimitive.Input
+    <ComboboxPrimitive.Input
       ref={ref}
       placeholder={placeholder}
       {...props}
@@ -82,55 +82,55 @@ const CommandInput = React.forwardRef<
   </div>
 ))
 
-CommandInput.displayName = CommandPrimitive.Input.displayName
+ComboboxInput.displayName = ComboboxPrimitive.Input.displayName
 
-const CommandList = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+const ComboboxList = React.forwardRef<
+  React.ElementRef<typeof ComboboxPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.List>
 >(({ ...props }, ref) => (
-  <CommandPrimitive.List
+  <ComboboxPrimitive.List
     ref={ref}
     {...props}
   />
 ))
 
-CommandList.displayName = CommandPrimitive.List.displayName
+ComboboxList.displayName = ComboboxPrimitive.List.displayName
 
-const CommandEmpty = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Empty>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+const ComboboxEmpty = React.forwardRef<
+  React.ElementRef<typeof ComboboxPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Empty>
 >((props, ref) => (
-  <CommandPrimitive.Empty
+  <ComboboxPrimitive.Empty
     ref={ref}
     {...props}
   />
 ))
 
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+ComboboxEmpty.displayName = ComboboxPrimitive.Empty.displayName
 
-const CommandGroup = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Group>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+const ComboboxGroup = React.forwardRef<
+  React.ElementRef<typeof ComboboxPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Group>
 >(({ ...props }, ref) => (
-  <CommandPrimitive.Group
+  <ComboboxPrimitive.Group
     ref={ref}
     {...props}
   />
 ))
 
-CommandGroup.displayName = CommandPrimitive.Group.displayName
+ComboboxGroup.displayName = ComboboxPrimitive.Group.displayName
 
-interface CommandItemProps extends React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item> {
+interface ComboboxItemProps extends React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Item> {
   checked?: boolean;
   asChild?: boolean;
 }
 
-const CommandItem = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Item>,
-  CommandItemProps
+const ComboboxItem = React.forwardRef<
+  React.ElementRef<typeof ComboboxPrimitive.Item>,
+  ComboboxItemProps
 >(({ children, checked, asChild, className, ...props }, ref) => {
-  const Comp = asChild ? Slot : CommandPrimitive.Item;
-  const { prefix, suffix, content } = useCommandItemSlots(children);
+  const Comp = asChild ? Slot : ComboboxPrimitive.Item;
+  const { prefix, suffix, content } = useComboboxItemSlots(children);
 
   if (asChild) {
     return (
@@ -141,7 +141,7 @@ const CommandItem = React.forwardRef<
   }
 
   return (
-    <CommandPrimitive.Item
+    <ComboboxPrimitive.Item
       ref={ref}
       className={`${checked ? 'command-item--checked' : ''} ${className || ''}`}
       {...props}
@@ -169,49 +169,57 @@ const CommandItem = React.forwardRef<
           )}
         </span>
       )}
-    </CommandPrimitive.Item>
+    </ComboboxPrimitive.Item>
   );
 });
 
-CommandItem.displayName = CommandPrimitive.Item.displayName
+ComboboxItem.displayName = ComboboxPrimitive.Item.displayName
 
-interface CommandItemPrefixProps extends React.HTMLAttributes<HTMLSpanElement> {
+interface ComboboxItemPrefixProps extends React.HTMLAttributes<HTMLSpanElement> {
   /** Content to be rendered in the prefix slot */
   children?: React.ReactNode;
 }
 
-const CommandItemPrefix = React.forwardRef<
+const ComboboxItemPrefix = React.forwardRef<
   HTMLSpanElement,
-  CommandItemPrefixProps
+  ComboboxItemPrefixProps
 >(({ children, ...props }, ref) => (
   <span ref={ref} slot="prefix" {...props}>
     {children}
   </span>
 ))
-CommandItemPrefix.displayName = "CommandItemPrefix"
+ComboboxItemPrefix.displayName = "ComboboxItemPrefix"
 
-interface CommandItemSuffixProps extends React.HTMLAttributes<HTMLSpanElement> {
+interface ComboboxItemSuffixProps extends React.HTMLAttributes<HTMLSpanElement> {
   /** Content to be rendered in the suffix slot */
   children?: React.ReactNode;
 }
 
-const CommandItemSuffix = React.forwardRef<
+const ComboboxItemSuffix = React.forwardRef<
   HTMLSpanElement,
-  CommandItemSuffixProps
+  ComboboxItemSuffixProps
 >(({ children, ...props }, ref) => (
   <span ref={ref} slot="suffix" {...props}>
     {children}
   </span>
 ))
-CommandItemSuffix.displayName = "CommandItemSuffix"
+ComboboxItemSuffix.displayName = "ComboboxItemSuffix"
 
 export {
-  Command,
-  CommandInput,
-  CommandList,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandItemPrefix,
-  CommandItemSuffix,
+  Combobox,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxItem,
+  ComboboxItemPrefix,
+  ComboboxItemSuffix,
+}
+
+export type {
+  ComboboxProps,
+  ComboboxInputProps,
+  ComboboxItemProps,
+  ComboboxItemPrefixProps,
+  ComboboxItemSuffixProps,
 }

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -134,7 +134,7 @@ const ComboboxItem = React.forwardRef<
 
   if (asChild) {
     return (
-      <Comp ref={ref} className={`${checked ? 'command-item--checked' : ''} ${className || ''}`}>
+      <Comp ref={ref} className={`${checked ? 'combobox-item--checked' : ''} ${className || ''}`}>
         {children}
       </Comp>
     );
@@ -143,27 +143,27 @@ const ComboboxItem = React.forwardRef<
   return (
     <ComboboxPrimitive.Item
       ref={ref}
-      className={`${checked ? 'command-item--checked' : ''} ${className || ''}`}
+      className={`${checked ? 'combobox-item--checked' : ''} ${className || ''}`}
       {...props}
     >
-      <span className="command-item__check">
+      <span className="combobox-item__check">
         <Icon icon="ph:check" aria-hidden="true" />
       </span>
 
       {prefix.length > 0 && (
-        <span className="command-item__prefix">
+        <span className="combobox-item__prefix">
           {prefix.map((child, index) =>
             React.cloneElement(child as React.ReactElement, { key: index })
           )}
         </span>
       )}
 
-      <span className="command-item__label">
+      <span className="combobox-item__label">
         {content}
       </span>
 
       {suffix.length > 0 && (
-        <span className="command-item__suffix">
+        <span className="combobox-item__suffix">
           {suffix.map((child, index) =>
             React.cloneElement(child as React.ReactElement, { key: index })
           )}

--- a/src/components/combobox/index.ts
+++ b/src/components/combobox/index.ts
@@ -1,0 +1,18 @@
+export {
+  Combobox,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxItem,
+  ComboboxItemPrefix,
+  ComboboxItemSuffix,
+} from './combobox';
+
+export type {
+  ComboboxProps,
+  ComboboxInputProps,
+  ComboboxItemProps,
+  ComboboxItemPrefixProps,
+  ComboboxItemSuffixProps,
+} from './combobox';

--- a/src/components/command-menu/ai-fallback-handler.tsx
+++ b/src/components/command-menu/ai-fallback-handler.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CommandEmpty, CommandGroup, CommandItem } from './command';
+import { ComboboxEmpty, ComboboxGroup, ComboboxItem } from '../combobox';
 import { Icon } from '@iconify/react';
 import { Slot } from "@radix-ui/react-slot";
 import { AIFallbackHandlerProps } from './ai-command-types';
@@ -56,14 +56,14 @@ export const AIFallbackHandler: React.FC<AIFallbackHandlerProps> = ({
   if (aiState.isProcessing) {
     return (
       <>
-        <CommandGroup>
-          <CommandItem disabled>
+        <ComboboxGroup>
+          <ComboboxItem disabled>
             <Slot slot="prefix">
               <Icon icon="ph:sparkle" />
             </Slot>
             <span className="shimmer">{aiProcessingMessage}</span>
-          </CommandItem>
-        </CommandGroup>
+          </ComboboxItem>
+        </ComboboxGroup>
       </>
     );
   }
@@ -74,9 +74,9 @@ export const AIFallbackHandler: React.FC<AIFallbackHandlerProps> = ({
 
     return (
       <>
-        <CommandGroup>
+        <ComboboxGroup>
           {result.suggestedItems.length > 0 && (
-            <CommandItem
+            <ComboboxItem
               onSelect={() => onApplyAIResult(result)}
             >
               {result.suggestedItems.length === 1 ? (
@@ -110,31 +110,31 @@ export const AIFallbackHandler: React.FC<AIFallbackHandlerProps> = ({
                   )
                 ]
               )}
-            </CommandItem>
+            </ComboboxItem>
           )}
 
           {/* Only show "no results" if there are truly no suggested items */}
           {result.suggestedItems.length === 0 && result.unmatchedCriteria && result.unmatchedCriteria.length > 0 && (
-            <CommandItem onSelect={handleCreateNewItem}>
+            <ComboboxItem onSelect={handleCreateNewItem}>
                <Slot slot="prefix">
                 <Icon icon="ph:sparkle" />
               </Slot>
               Create new task
-            </CommandItem>
+            </ComboboxItem>
           )}
 
           {/* Show partial match indicator when there are both matches and unmatched criteria */}
           {result.suggestedItems.length > 0 && result.unmatchedCriteria && result.unmatchedCriteria.length > 0 && (
-            <CommandItem onSelect={handleCreateNewItem}>
+            <ComboboxItem onSelect={handleCreateNewItem}>
               <Slot slot="prefix">
                 <Icon icon="ph:warning" />
               </Slot>
               <span>
                 Partial match - couldn't understand: {result.unmatchedCriteria.join(', ')}
               </span>
-            </CommandItem>
+            </ComboboxItem>
           )}
-        </CommandGroup>
+        </ComboboxGroup>
       </>
     );
   }
@@ -142,9 +142,9 @@ export const AIFallbackHandler: React.FC<AIFallbackHandlerProps> = ({
   if (aiState.error) {
     return (
       <>
-        <CommandEmpty>
+        <ComboboxEmpty>
           {aiErrorPrefix} {aiState.error}
-        </CommandEmpty>
+        </ComboboxEmpty>
       </>
     );
   }
@@ -152,9 +152,9 @@ export const AIFallbackHandler: React.FC<AIFallbackHandlerProps> = ({
   // Default empty state
   return (
     <>
-      <CommandEmpty>
+      <ComboboxEmpty>
         {searchInput.trim() ? noResultsMessage : emptyStateMessage}
-      </CommandEmpty>
+      </ComboboxEmpty>
     </>
   );
 };

--- a/src/components/command-menu/command-menu.tsx
+++ b/src/components/command-menu/command-menu.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from './command';
+  Combobox,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from '../combobox';
 import { AIFallbackHandler } from './ai-fallback-handler';
 import { useCommandComposition } from './hooks/use-command-composition';
 import type {
@@ -66,19 +66,19 @@ export function CommandMenu({
   const effectivePlaceholder = placeholder ?? composition.placeholder;
 
   return (
-    <Command
+    <Combobox
       label="Command menu"
       shouldFilter={false}
       onKeyDown={composition.keyboard.handleKeyDown}
       className={className}
     >
-      <CommandInput
+      <ComboboxInput
         placeholder={effectivePlaceholder}
         value={composition.searchInput}
         onValueChange={composition.setSearchInput}
         ref={composition.keyboard.inputRef}
       />
-      <CommandList>
+      <ComboboxList>
         {composition.shouldShowAI && composition.ai && (
           <AIFallbackHandler
             searchInput={composition.searchInput}
@@ -99,13 +99,13 @@ export function CommandMenu({
         )}
 
         {!composition.shouldShowAI && !composition.hasResults && (
-          <CommandEmpty>{emptyMessage}</CommandEmpty>
+          <ComboboxEmpty>{emptyMessage}</ComboboxEmpty>
         )}
 
         {composition.shouldShowRecents && composition.results.recents.length > 0 && (
-          <CommandGroup heading="Recent">
+          <ComboboxGroup heading="Recent">
             {composition.results.recents.map((item) => (
-              <CommandItem
+              <ComboboxItem
                 key={item.id}
                 onSelect={() => composition.navigation.handleRecentSelect(item.id)}
               >
@@ -113,15 +113,15 @@ export function CommandMenu({
                   <iconify-icon icon={item.icon as string} slot="prefix"></iconify-icon>
                 )}
                 {item.name}
-              </CommandItem>
+              </ComboboxItem>
             ))}
-          </CommandGroup>
+          </ComboboxGroup>
         )}
 
         {composition.isInChildView ? (
-          <CommandGroup>
+          <ComboboxGroup>
             {composition.results.children.map(({ child }) => (
-              <CommandItem
+              <ComboboxItem
                 key={child.id}
                 onSelect={() => composition.navigation.handleChildSelect(child.id)}
               >
@@ -129,15 +129,15 @@ export function CommandMenu({
                   <iconify-icon icon={child.icon as string} slot="prefix"></iconify-icon>
                 )}
                 {child.name}
-              </CommandItem>
+              </ComboboxItem>
             ))}
-          </CommandGroup>
+          </ComboboxGroup>
         ) : (
           <>
             {composition.results.commands.length > 0 && (
-              <CommandGroup heading="Commands">
+              <ComboboxGroup heading="Commands">
                 {composition.results.commands.map((command) => (
-                  <CommandItem
+                  <ComboboxItem
                     key={command.id}
                     onSelect={() => {
                       if (enableNavigation && command.children?.length) {
@@ -157,15 +157,15 @@ export function CommandMenu({
                         {composition.keyboard.formatShortcut([...command.shortcut])}
                       </span>
                     )}
-                  </CommandItem>
+                  </ComboboxItem>
                 ))}
-              </CommandGroup>
+              </ComboboxGroup>
             )}
 
             {composition.results.children.length > 0 && (
-              <CommandGroup heading="Actions">
+              <ComboboxGroup heading="Actions">
                 {composition.results.children.map(({ parent, child }) => (
-                  <CommandItem
+                  <ComboboxItem
                     key={`${parent.id}-${child.id}`}
                     onSelect={() => composition.navigation.handleChildSelect(child.id)}
                   >
@@ -173,13 +173,13 @@ export function CommandMenu({
                       <iconify-icon icon={child.icon as string} slot="prefix"></iconify-icon>
                     )}
                     {parent.name} {child.name}
-                  </CommandItem>
+                  </ComboboxItem>
                 ))}
-              </CommandGroup>
+              </ComboboxGroup>
             )}
           </>
         )}
-      </CommandList>
-    </Command>
+      </ComboboxList>
+    </Combobox>
   );
 }

--- a/src/components/command-menu/index.ts
+++ b/src/components/command-menu/index.ts
@@ -1,14 +1,3 @@
-export {
-  Command,
-  CommandInput,
-  CommandList,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandItemPrefix,
-  CommandItemSuffix,
-} from './command';
-
 export { AIFallbackHandler } from './ai-fallback-handler';
 
 // Core hooks

--- a/src/components/filter/filter-components.tsx
+++ b/src/components/filter/filter-components.tsx
@@ -5,13 +5,13 @@ import { FilterIcon } from "./filter-options-icons";
 import { AnimateChangeInHeight } from "./animate-change-in-height";
 import { Slot } from "@radix-ui/react-slot";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "../command-menu/command";
+  Combobox,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "../combobox";
 import { useDropdownState } from "./hooks/use-dropdown-state";
 import 'iconify-icon';
 import '../dropdown/dropdown.ts';
@@ -64,7 +64,7 @@ export const FilterValueDropdown = ({
 }) => {
   const {
     commandInput,
-    setCommandInput,
+    setComboboxInput,
     commandInputRef,
     dropdownRef,
     handleDropdownShow,
@@ -113,35 +113,35 @@ export const FilterValueDropdown = ({
 
       <div>
         <AnimateChangeInHeight>
-          <Command>
-            <CommandInput
+          <Combobox>
+            <ComboboxInput
               placeholder={filterType}
               className="h-9"
               value={commandInput}
               onInputCapture={(e) => {
-                setCommandInput(e.currentTarget.value);
+                setComboboxInput(e.currentTarget.value);
               }}
               ref={commandInputRef}
             />
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup>
+            <ComboboxList>
+              <ComboboxEmpty>No results found.</ComboboxEmpty>
+              <ComboboxGroup>
                 {filterValues.map((value) => (
-                  <CommandItem
+                  <ComboboxItem
                     key={value}
                     checked={true}
                     onSelect={() => handleValueRemove(value)}
                   >
                     <FilterIcon type={value as FilterType} slot="prefix" />
                     {value}
-                  </CommandItem>
+                  </ComboboxItem>
                 ))}
-              </CommandGroup>
+              </ComboboxGroup>
               {nonSelectedFilterValues?.length > 0 && (
                 <>
-                  <CommandGroup>
+                  <ComboboxGroup>
                     {nonSelectedFilterValues.map((filter: FilterOption) => (
-                      <CommandItem
+                      <ComboboxItem
                         key={filter.name}
                         value={filter.name}
                         checked={false}
@@ -158,13 +158,13 @@ export const FilterValueDropdown = ({
                             {filter.label}
                           </span>
                         )}
-                      </CommandItem>
+                      </ComboboxItem>
                     ))}
-                  </CommandGroup>
+                  </ComboboxGroup>
                 </>
               )}
-            </CommandList>
-          </Command>
+            </ComboboxList>
+          </Combobox>
         </AnimateChangeInHeight>
       </div>
     </pp-dropdown>

--- a/src/components/filter/index.ts
+++ b/src/components/filter/index.ts
@@ -19,16 +19,5 @@ export { useDropdownState } from './hooks/use-dropdown-state';
 // Type declarations
 import './filter-component-types';
 
-// Re-export command menu components
-export {
-  Command,
-  CommandInput,
-  CommandList,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandItemPrefix,
-  CommandItemSuffix,
-  AIFallbackHandler,
-  useAICommand
-} from '../command-menu';
+// Re-export AI command menu utilities
+export { AIFallbackHandler, useAICommand } from '../command-menu';

--- a/src/components/reference/ReferencePicker.tsx
+++ b/src/components/reference/ReferencePicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   Combobox,
   ComboboxGroup,
@@ -10,13 +10,12 @@ import { useHierarchicalNavigation, type SearchableParent, type SearchableItem }
 import { createSortedSearchFunction, sortByRelevance } from '../../utility/hierarchical-search';
 import type {
   SelectedReference,
-  ReferencePickerProps,
-  ReferencePickerRef
+  ReferencePickerProps
 } from './types';
 import 'iconify-icon';
 import '../../jsx-types';
 
-export const ReferencePicker = forwardRef<ReferencePickerRef, ReferencePickerProps>(({
+export const ReferencePicker = ({
   data,
   query = '',
   onSelect,
@@ -28,11 +27,11 @@ export const ReferencePicker = forwardRef<ReferencePickerRef, ReferencePickerPro
   selectedCategory: _selectedCategory = null,
   onCategorySelect,
   onBack
-}, ref) => {
+}: ReferencePickerProps) => {
 
   const hierarchicalData = data as SearchableParent[];
-  
-  const { state, actions, results, inputRef } = useHierarchicalNavigation({
+
+  const { state, actions, results } = useHierarchicalNavigation({
     data: hierarchicalData,
     searchFunction: createSortedSearchFunction(
       (categories, query) => sortByRelevance(categories, query),
@@ -72,17 +71,6 @@ export const ReferencePicker = forwardRef<ReferencePickerRef, ReferencePickerPro
       onBack?.();
     }
   }, [actions, onClose, onBack, state.mode]);
-
-  useImperativeHandle(ref, () => ({
-    focus: () => {
-      inputRef.current?.focus();
-    },
-    selectFirst: () => {},
-    selectLast: () => {},
-    selectNext: () => {},
-    selectPrevious: () => {},
-    getSelectedReference: () => null,
-  }), [inputRef]);
 
   if (!open) return null;
 
@@ -171,6 +159,4 @@ export const ReferencePicker = forwardRef<ReferencePickerRef, ReferencePickerPro
       </Combobox>
     </div>
   );
-});
-
-ReferencePicker.displayName = 'ReferencePicker';
+};

--- a/src/components/reference/ReferencePicker.tsx
+++ b/src/components/reference/ReferencePicker.tsx
@@ -1,11 +1,11 @@
 import { forwardRef, useImperativeHandle, useCallback, useMemo } from 'react';
 import {
-  Command,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-  CommandEmpty
-} from '../command-menu/command';
+  Combobox,
+  ComboboxGroup,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxEmpty
+} from '../combobox';
 import { useHierarchicalNavigation, type SearchableParent, type SearchableItem } from '../../hooks/useHierarchicalNavigation';
 import { createSortedSearchFunction, sortByRelevance } from '../../utility/hierarchical-search';
 import type {
@@ -92,18 +92,18 @@ export const ReferencePicker = forwardRef<ReferencePickerRef, ReferencePickerPro
       aria-label="Reference picker"
       data-reference-picker
     >
-      <Command
+      <Combobox
         label="Reference picker"
         shouldFilter={false}
         onEscape={handleEscape}
       >
-        <CommandList>
+        <ComboboxList>
           {state.mode === 'contextual' ? (
             <>
               {results.contextualItems && results.contextualItems.length > 0 ? (
-                <CommandGroup>
+                <ComboboxGroup>
                   {results.contextualItems.map((item) => (
-                    <CommandItem
+                    <ComboboxItem
                       key={item.id}
                       onSelect={() => actions.selectChild(item)}
                     >
@@ -112,19 +112,19 @@ export const ReferencePicker = forwardRef<ReferencePickerRef, ReferencePickerPro
                         slot="prefix"
                       />
                       {item.name}
-                    </CommandItem>
+                    </ComboboxItem>
                   ))}
-                </CommandGroup>
+                </ComboboxGroup>
               ) : (
-                <CommandEmpty>No {state.selectedContext?.name?.toLowerCase() ?? 'items'} found.</CommandEmpty>
+                <ComboboxEmpty>No {state.selectedContext?.name?.toLowerCase() ?? 'items'} found.</ComboboxEmpty>
               )}
             </>
           ) : (
             <>
               {results.parents.length > 0 && (
-                <CommandGroup>
+                <ComboboxGroup>
                   {results.parents.map((category) => (
-                    <CommandItem
+                    <ComboboxItem
                       key={category.id}
                       onSelect={() => handleCategorySelect(category)}
                     >
@@ -137,15 +137,15 @@ export const ReferencePicker = forwardRef<ReferencePickerRef, ReferencePickerPro
                         icon="ph:caret-right"
                         slot="suffix"
                       />
-                    </CommandItem>
+                    </ComboboxItem>
                   ))}
-                </CommandGroup>
+                </ComboboxGroup>
               )}
 
               {results.children.length > 0 && (
-                <CommandGroup>
+                <ComboboxGroup>
                   {results.children.map(({ parent, child }) => (
-                    <CommandItem
+                    <ComboboxItem
                       key={`${parent.id}-${child.id}`}
                       onSelect={() => actions.selectChild(child)}
                     >
@@ -154,21 +154,21 @@ export const ReferencePicker = forwardRef<ReferencePickerRef, ReferencePickerPro
                         slot="prefix"
                       />
                       {child.name}
-                    </CommandItem>
+                    </ComboboxItem>
                   ))}
-                </CommandGroup>
+                </ComboboxGroup>
               )}
 
               {state.searchInput &&
                state.searchInput.length >= 2 &&
                results.parents.length === 0 &&
                results.children.length === 0 && (
-                <CommandEmpty>No references found for "{state.searchInput}".</CommandEmpty>
+                <ComboboxEmpty>No references found for "{state.searchInput}".</ComboboxEmpty>
               )}
             </>
           )}
-        </CommandList>
-      </Command>
+        </ComboboxList>
+      </Combobox>
     </div>
   );
 });

--- a/src/components/reference/types.ts
+++ b/src/components/reference/types.ts
@@ -86,11 +86,3 @@ export interface ReferencePickerProps {
   onBack?: () => void;
 }
 
-export interface ReferencePickerRef {
-  focus: () => void;
-  selectFirst: () => void;
-  selectLast: () => void;
-  selectNext: () => void;
-  selectPrevious: () => void;
-  getSelectedReference: () => SelectedReference | null;
-}

--- a/src/jsx-types.ts
+++ b/src/jsx-types.ts
@@ -65,12 +65,15 @@ declare module 'react' {
         activation?: 'auto' | 'manual';
         'no-scroll-controls'?: boolean;
       };
-      'pp-list': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+      'pp-list': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        multiselectable?: boolean;
+      };
       'pp-list-item': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
         type?: 'checkbox' | 'radio' | string;
         disabled?: boolean;
         defaultChecked?: boolean;
         checked?: boolean;
+        value?: string;
         onClick?: () => void;
       };
       'pp-dropdown': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {

--- a/src/pattern-graph.json
+++ b/src/pattern-graph.json
@@ -160,6 +160,16 @@
       "role": "component"
     },
     {
+      "id": "actions-coordination-dual-listbox",
+      "title": "Dual listbox",
+      "category": "Actions",
+      "path": "../?path=/docs/actions-coordination-dual-listbox--docs",
+      "role": "pattern",
+      "tags": [
+        "adjacent-to"
+      ]
+    },
+    {
       "id": "actions-coordination-messaging",
       "title": "Messaging",
       "category": "Actions",
@@ -712,6 +722,18 @@
         "operatesOn": "a single binary preference the actor wants to commit without leaving the surrounding flow",
         "produces": "a visible on/off state the actor can flip in place",
         "enacts": "legibility of state, continuity with the surrounding flow"
+      }
+    },
+    {
+      "id": "operations-combobox",
+      "title": "Combobox",
+      "category": "Operations",
+      "path": "../?path=/docs/operations-combobox--docs",
+      "role": "component",
+      "generativeProfile": {
+        "operatesOn": "a value drawn from a long, unfamiliar, or dynamically fetched option set",
+        "produces": "a text input bound to a filtered popup list: type to narrow, activate to commit",
+        "enacts": "recognition over recall, economy of typing, predictable keyboard navigation"
       }
     },
     {
@@ -2314,6 +2336,48 @@
       "label": "shares the overlay mechanism but is target-triggered (right-click) rather than button-triggered"
     },
     {
+      "source": "actions-coordination-selection",
+      "target": "actions-coordination-dual-listbox",
+      "type": "precedes",
+      "label": "the commitment model is a staged variant of multi-selection; the explicit review step before confirm is what distinguishes it",
+      "extractedFrom": "header:\"Precursors\""
+    },
+    {
+      "source": "operations-combobox",
+      "target": "actions-coordination-dual-listbox",
+      "type": "precedes",
+      "label": "the lighter-weight alternative when full side-by-side review isn't needed",
+      "extractedFrom": "header:\"Precursors\""
+    },
+    {
+      "source": "actions-coordination-dual-listbox",
+      "target": "actions-coordination-action-bar",
+      "type": "complements",
+      "label": "the immediate-action alternative; when \"assign these to that\" is a bulk action on an existing selection without a review step, an action bar suffices",
+      "extractedFrom": "header:\"Complementary\""
+    },
+    {
+      "source": "actions-coordination-dual-listbox",
+      "target": "actions-application-form",
+      "type": "complements",
+      "label": "dual listbox typically lives inside a dialog or form, with a confirm button that commits the assignment",
+      "extractedFrom": "header:\"Complementary\""
+    },
+    {
+      "source": "actions-coordination-dual-listbox",
+      "target": "actions-seeking-filtering",
+      "type": "tangential",
+      "label": "source lists often need search/filter when the pool is large",
+      "extractedFrom": "header:\"Tangentially related\""
+    },
+    {
+      "source": "actions-coordination-dual-listbox",
+      "target": "actions-seeking-sorting",
+      "type": "tangential",
+      "label": "destination list order may be significant (priority, ranking), requiring reorder controls",
+      "extractedFrom": "header:\"Tangentially related\""
+    },
+    {
       "source": "actions-coordination-messaging",
       "target": "activities-bot",
       "type": "related",
@@ -3093,6 +3157,13 @@
       "label": "optimised for getting the job done"
     },
     {
+      "source": "operations-combobox",
+      "target": "actions-seeking-command-menu",
+      "type": "precedes",
+      "label": "the mechanism this pattern builds on; `src/components/combobox/` drives the text input, filtered list, and keyboard model",
+      "extractedFrom": "header:\"Precursors\""
+    },
+    {
       "source": "operations-keyboard-key",
       "target": "actions-seeking-command-menu",
       "type": "precedes",
@@ -3238,6 +3309,13 @@
       "source": "actions-seeking-command-menu",
       "target": "actions-seeking-filtering",
       "type": "precedes",
+      "extractedFrom": "header:\"Precursors\""
+    },
+    {
+      "source": "operations-combobox",
+      "target": "actions-seeking-filtering",
+      "type": "precedes",
+      "label": "the value-picker inside each active filter chip uses a combobox to narrow available values",
       "extractedFrom": "header:\"Precursors\""
     },
     {
@@ -3428,6 +3506,13 @@
       "source": "actions-seeking-searching",
       "target": "operations-autocomplete",
       "type": "complements",
+      "extractedFrom": "header:\"Complementary\""
+    },
+    {
+      "source": "actions-seeking-searching",
+      "target": "operations-combobox",
+      "type": "complements",
+      "label": "the entry-phase mechanism for instant-results variants (popover/dropdown); the search input binding follows the combobox contract.",
       "extractedFrom": "header:\"Complementary\""
     },
     {
@@ -5116,6 +5201,13 @@
       "extractedFrom": "header:\"Precursors\""
     },
     {
+      "source": "operations-combobox",
+      "target": "operations-autocomplete",
+      "type": "precedes",
+      "label": "the WAI-ARIA contract this pattern builds on: text input + popup listbox + keyboard model",
+      "extractedFrom": "header:\"Precursors\""
+    },
+    {
       "source": "operations-good-defaults",
       "target": "operations-autocomplete",
       "type": "precedes",
@@ -5314,6 +5406,48 @@
       "target": "actions-application-form",
       "type": "related",
       "label": "validation and instructional feedback patterns"
+    },
+    {
+      "source": "operations-input",
+      "target": "operations-combobox",
+      "type": "enables",
+      "label": "the text field half of the contract, without the popup",
+      "extractedFrom": "header:\"Containers and primitives\""
+    },
+    {
+      "source": "operations-select",
+      "target": "operations-combobox",
+      "type": "enables",
+      "label": "the simpler counterpart for short, bounded sets already known to the actor",
+      "extractedFrom": "header:\"Containers and primitives\""
+    },
+    {
+      "source": "operations-combobox",
+      "target": "actions-seeking-command-menu",
+      "type": "instantiates",
+      "label": "the combobox contract drives hierarchical navigation and command activation",
+      "extractedFrom": "header:\"Applied in\""
+    },
+    {
+      "source": "operations-combobox",
+      "target": "actions-seeking-filtering",
+      "type": "instantiates",
+      "label": "each filter chip's value-picker uses a combobox to narrow available values",
+      "extractedFrom": "header:\"Applied in\""
+    },
+    {
+      "source": "operations-combobox",
+      "target": "operations-autocomplete",
+      "type": "instantiates",
+      "label": "narrowing-as-you-type is the combobox contract applied to query suggestion",
+      "extractedFrom": "header:\"Applied in\""
+    },
+    {
+      "source": "operations-combobox",
+      "target": "actions-seeking-searching",
+      "type": "instantiates",
+      "label": "the entry phase of instant-results search (popover or dropdown variant) follows the combobox model",
+      "extractedFrom": "header:\"Applied in\""
     },
     {
       "source": "operations-deep-linking",
@@ -5634,6 +5768,13 @@
       "type": "complements",
       "label": "the broader activity select participates in.",
       "extractedFrom": "header:\"Complementary\""
+    },
+    {
+      "source": "operations-select",
+      "target": "operations-combobox",
+      "type": "precedes",
+      "label": "for searchable, async, or custom-rendered option sets, built on the WAI-ARIA APG combobox pattern.",
+      "extractedFrom": "header:\"Follow-ups\""
     },
     {
       "source": "operations-status-feedback",

--- a/src/stories/actions/coordination/ActionBar.mdx
+++ b/src/stories/actions/coordination/ActionBar.mdx
@@ -49,6 +49,7 @@ The action bar should hold operations that *only make sense against a selection*
 - [Priority+](../?path=/docs/actions-coordination-priority--docs) — handles overflow when the action group is too wide for the available width
 - [Unavailable actions](../?path=/docs/operations-unavailable-actions--docs) — governs which actions appear or disable as the selection scope changes
 - [Modality](../?path=/docs/foundations-modality--docs) — action bars are non-modal: the underlying content remains interactive
+- [Dual listbox](../?path=/docs/actions-coordination-dual-listbox--docs) — an alternative when the operation is "assign these items to that group" and the actor needs to review source and destination side by side before committing; the action bar model favours immediate action, the dual listbox model favours staged review
 
 ### Follow-ups
 

--- a/src/stories/actions/coordination/ActionBar.mdx
+++ b/src/stories/actions/coordination/ActionBar.mdx
@@ -49,7 +49,6 @@ The action bar should hold operations that *only make sense against a selection*
 - [Priority+](../?path=/docs/actions-coordination-priority--docs) — handles overflow when the action group is too wide for the available width
 - [Unavailable actions](../?path=/docs/operations-unavailable-actions--docs) — governs which actions appear or disable as the selection scope changes
 - [Modality](../?path=/docs/foundations-modality--docs) — action bars are non-modal: the underlying content remains interactive
-- [Dual listbox](../?path=/docs/actions-coordination-dual-listbox--docs) — an alternative when the operation is "assign these items to that group" and the actor needs to review source and destination side by side before committing; the action bar model favours immediate action, the dual listbox model favours staged review
 
 ### Follow-ups
 

--- a/src/stories/actions/coordination/DualListbox.mdx
+++ b/src/stories/actions/coordination/DualListbox.mdx
@@ -1,0 +1,66 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Actions/Coordination/Dual listbox" tags={['activity-level:action', 'atomic:pattern', 'role:pattern', 'lifecycle:coordination', 'mediation:coordination']} />
+
+> 🌱 **Seed** — no project example yet. See TODO below.
+
+> 🤔 **Fun meter: 3/5**. Dual listbox is regularly cited as a UX anti-pattern, but that critique targets overuse. The more interesting question is when "staged commit with full review" actually justifies two lists.
+
+# Dual listbox
+
+A side-by-side pair of scrollable lists — source pool and selection set — with transfer controls between them, so the actor can inspect both before committing a bulk assignment.
+
+## The situation
+
+The actor needs to assign a set of items from a pool to a destination. The assignment is consequential enough that seeing both the available candidates and the growing selection simultaneously — before confirming — is worth the extra surface area.
+
+A plain [multiselect](../?path=/docs/operations-combobox--docs) (combobox with checked items) commits items one at a time without showing the full selected set alongside the remaining pool. When the assignment is bulk, high-stakes, or requires cross-referencing ("am I leaving the right items behind?"), a staged view reduces error.
+
+## Forces
+
+- **Commitment scale** — the larger the assignment, the more the actor benefits from seeing the full "going" set before acting.
+- **Error cost** — when undoing is expensive or requires escalation, staging review before confirming is a net win even if the UI is heavier.
+- **Reviewability** — the side-by-side layout makes visible what multiselect hides (the selected set) and what a confirm-on-activate model destroys (the candidate pool).
+
+## Anatomy
+
+Two scrollable lists with a transfer zone between them:
+
+- *Source list* — the candidate pool, minus what has already been assigned. Supports search/filter when the pool is large.
+- *Transfer controls* — at minimum: "Add selected →" / "← Remove selected". Often supplemented by "Add all →" / "← Remove all". Keyboard: Arrow keys navigate within each list; Space (or Alt+Arrow) transfers a focused item.
+- *Destination list* — the accumulating selection. Order may matter (drag to reorder) or be irrelevant.
+- *Confirm action* — outside the widget. Transfers are tentative until the actor explicitly applies.
+
+## When to use
+
+Dual listbox earns its weight when:
+- The assignment involves enough items that a single scrollable popup obscures the full picture
+- The actor needs to verify what *remains* in the source after removing items
+- The widget lives in a staged context — a bulk-edit dialog or wizard step — so the dedicated layout isn't wasted on a routine interaction
+
+Prefer [multiselect](../?path=/docs/operations-combobox--docs) (checkboxes in a combobox popup) when the set is short, the commitment is cheap and reversible, or the actor adds items one at a time and progressive chip feedback is enough.
+
+## TODO
+
+No project example exists yet. A good motivating case: an "assign labels to tasks" bulk dialog, or a "grant roles to users" screen. Add one when the use case surfaces naturally in the project — this stub exists so [Selection](../?path=/docs/actions-coordination-selection--docs) and [Action bar](../?path=/docs/actions-coordination-action-bar--docs) can cross-link to it.
+
+## Related patterns
+
+### Precursors
+
+- [Selection](../?path=/docs/actions-coordination-selection--docs) — the commitment model is a staged variant of multi-selection; the explicit review step before confirm is what distinguishes it
+- [Combobox](../?path=/docs/operations-combobox--docs) — the lighter-weight alternative when full side-by-side review isn't needed
+
+### Complementary
+
+- [Action bar](../?path=/docs/actions-coordination-action-bar--docs) — the immediate-action alternative; when "assign these to that" is a bulk action on an existing selection without a review step, an action bar suffices
+- [Form](../?path=/docs/actions-application-form--docs) — dual listbox typically lives inside a dialog or form, with a confirm button that commits the assignment
+
+### Tangentially related
+
+- [Filtering](../?path=/docs/actions-seeking-filtering--docs) — source lists often need search/filter when the pool is large
+- [Sorting](../?path=/docs/actions-seeking-sorting--docs) — destination list order may be significant (priority, ranking), requiring reorder controls
+
+## Resources & references
+
+- Smashing Magazine — [Combobox vs Multiselect vs Listbox](https://www.smashingmagazine.com/2026/02/combobox-vs-multiselect-vs-listbox/)

--- a/src/stories/actions/coordination/DualListbox.mdx
+++ b/src/stories/actions/coordination/DualListbox.mdx
@@ -2,13 +2,11 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Actions/Coordination/Dual listbox" tags={['activity-level:action', 'atomic:pattern', 'role:pattern', 'lifecycle:coordination', 'mediation:coordination']} />
 
-> 🌱 **Seed** — no project example yet. See TODO below.
-
-> 🤔 **Fun meter: 3/5**. Dual listbox is regularly cited as a UX anti-pattern, but that critique targets overuse. The more interesting question is when "staged commit with full review" actually justifies two lists.
+> 🤔 **Fun meter: 2/5**. Dependency. 
 
 # Dual listbox
 
-A side-by-side pair of scrollable lists — source pool and selection set — with transfer controls between them, so the actor can inspect both before committing a bulk assignment.
+A side-by-side pair of lists — source pool and selection set — with transfer controls, so the actor can inspect both before committing a bulk assignment.
 
 ## The situation
 
@@ -21,28 +19,6 @@ A plain [multiselect](../?path=/docs/operations-combobox--docs) (combobox with c
 - **Commitment scale** — the larger the assignment, the more the actor benefits from seeing the full "going" set before acting.
 - **Error cost** — when undoing is expensive or requires escalation, staging review before confirming is a net win even if the UI is heavier.
 - **Reviewability** — the side-by-side layout makes visible what multiselect hides (the selected set) and what a confirm-on-activate model destroys (the candidate pool).
-
-## Anatomy
-
-Two scrollable lists with a transfer zone between them:
-
-- *Source list* — the candidate pool, minus what has already been assigned. Supports search/filter when the pool is large.
-- *Transfer controls* — at minimum: "Add selected →" / "← Remove selected". Often supplemented by "Add all →" / "← Remove all". Keyboard: Arrow keys navigate within each list; Space (or Alt+Arrow) transfers a focused item.
-- *Destination list* — the accumulating selection. Order may matter (drag to reorder) or be irrelevant.
-- *Confirm action* — outside the widget. Transfers are tentative until the actor explicitly applies.
-
-## When to use
-
-Dual listbox earns its weight when:
-- The assignment involves enough items that a single scrollable popup obscures the full picture
-- The actor needs to verify what *remains* in the source after removing items
-- The widget lives in a staged context — a bulk-edit dialog or wizard step — so the dedicated layout isn't wasted on a routine interaction
-
-Prefer [multiselect](../?path=/docs/operations-combobox--docs) (checkboxes in a combobox popup) when the set is short, the commitment is cheap and reversible, or the actor adds items one at a time and progressive chip feedback is enough.
-
-## TODO
-
-No project example exists yet. A good motivating case: an "assign labels to tasks" bulk dialog, or a "grant roles to users" screen. Add one when the use case surfaces naturally in the project — this stub exists so [Selection](../?path=/docs/actions-coordination-selection--docs) and [Action bar](../?path=/docs/actions-coordination-action-bar--docs) can cross-link to it.
 
 ## Related patterns
 

--- a/src/stories/actions/coordination/Selection.mdx
+++ b/src/stories/actions/coordination/Selection.mdx
@@ -1,6 +1,7 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import * as SelectionStories from './Selection.stories.tsx';
 
-<Meta title="Actions/Coordination/Selection" tags={['activity-level:action', 'atomic:pattern', 'role:pattern', 'lifecycle:coordination', 'mediation:individual']} />
+<Meta of={SelectionStories} tags={['activity-level:action', 'atomic:pattern', 'role:pattern', 'lifecycle:coordination', 'mediation:individual']} />
 
 > 😣 *Fun meter: 3/5*. Selection looks trivial until you ask what it means for a selection to survive a filter.
 
@@ -29,6 +30,21 @@ The "current item" model. The actor picks one thing; picking another replaces th
 Non-contiguous, additive. The actor builds up a set by ticking checkboxes or modifier-clicking. The set has no internal order beyond insertion; each item is in or out independently of the others.
 
 Multi-selection is where most of the design pressure on [action bars](../?path=/docs/actions-coordination-action-bar--docs) comes from: the action set is a function of the selected set, and operations that apply to one item but not to many (or vice versa) have to disable or disappear as the count changes.
+
+The same multi-cardinality model shows up inside a [combobox](../?path=/docs/operations-combobox--docs) when the value being committed is itself a set — filter value pickers and tag selectors are the canonical cases. The substrate is identical (popup listbox, type-to-narrow, commit-to-set); only the cardinality changes.
+
+#### Ambient feedback for the selected set
+
+Once selection counts climb past one or two, the count alone stops being legible — the actor needs to see *what* is in the set, not just how many. Two common surfaces:
+
+- *Inline state on the items themselves* — checkmarks, tick rows, highlight on selected rows. Cheap, but invisible the moment the actor scrolls past the selection.
+- *Chip rendering elsewhere on the canvas* — selected items rendered as removable chips in a header strip, side panel, or toolbar. Survives scroll, doubles as a remove-from-selection affordance, but costs layout.
+
+The chip strip earns its weight when the selection is intended to outlive the current view (e.g. building up a set across paged or filtered results). The list-only feedback is fine when the selection is consumed immediately, in-view.
+
+#### Select all / Clear all threshold
+
+A "Select all" master checkbox and a "Clear" affordance are the cheapest way to make the cardinality of the operation explicit. They earn their weight roughly when the visible set exceeds ~5 items, or when "all" is a coherent operation in the actor's mental model (the inbox, the search results, the filter match). Below that threshold, individual ticks are faster than reading and resolving a master state.
 
 ### Range selection
 
@@ -68,15 +84,29 @@ When 50 of 10,000 items are visible and the actor clicks the master checkbox, wh
 - *All matching* — selects all 10,000 that match the current filter. What the actor probably wants, but invisible to them; needs explicit confirmation.
 - *All in collection* — selects all items in the underlying collection regardless of filter. Almost never what the actor wants and usually a bug.
 
-A go-to solution is to select the visible view first, then offer a follow-up affordance ("Select all 1,234 items") that escalates to the matching set.
+A go-to solution is to select the visible view first, then offer a follow-up affordance ("Select all 1,234 items") that escalates to the matching set. Two-step opt-in: the actor sees the consequence of the smaller commitment before being offered the larger one.
+
+<Canvas>
+  <Story of={SelectionStories.SelectAllAffordance} />
+</Canvas>
 
 ## Visibility and discoverability
 
 How does the actor learn that items are selectable in the first place?
 
 - *Always-visible checkboxes* — maximum discoverability, maximum visual noise. Appropriate when selection is a primary capability of the view (inboxes, file managers).
+
+<Canvas>
+  <Story of={SelectionStories.InlineCheckboxes} />
+</Canvas>
+
 - *Hover-revealed checkboxes* — checkboxes appear on row hover, persist when selected. Reduces visual noise without hiding the affordance entirely. Doesn't work on touch.
-- *Mode-based selection* — an explicit select/edit toggle reveals checkboxes.
+- *Mode-based selection* — an explicit select/edit toggle reveals checkboxes. Common on touch surfaces where hover doesn't exist, and on content-first views where always-on selection would dominate the layout.
+
+<Canvas>
+  <Story of={SelectionStories.ModeBasedReveal} />
+</Canvas>
+
 - *Implicit selection through pointer gestures* — no checkboxes; click-to-select, shift+click for range, `ctrl`+`click` for set.
 
 ## Selection and filter as duals

--- a/src/stories/actions/coordination/Selection.mdx
+++ b/src/stories/actions/coordination/Selection.mdx
@@ -130,6 +130,7 @@ Filter is declarative selection ("everything matching X"); selection is imperati
 - [Filtering](../?path=/docs/actions-seeking-filtering--docs) — Filtering and selection cover the same job from opposite ends — filter narrows by predicate, selection narrows by enumeration
 - [Sorting](../?path=/docs/actions-seeking-sorting--docs) — Sorting changes what a range selection refers to mid-flight — range selections have to either survive the sort or re-resolve to the new order
 - [Searching](../?path=/docs/actions-seeking-searching--docs) — Search shrinks the population from which selections are drawn
+- [Dual listbox](../?path=/docs/actions-coordination-dual-listbox--docs) — the staged-commit variant; when a bulk assignment needs side-by-side review of source and selection before applying
 
 ### Composed from
 

--- a/src/stories/actions/coordination/Selection.mdx
+++ b/src/stories/actions/coordination/Selection.mdx
@@ -11,11 +11,11 @@ The staking of a subset of items or content as the target of subsequent action, 
 
 ## Dimensions
 
-- *Cardinality* — single, multi (set), range (contiguous span). These have different mental models and different input grammars; a UI that pretends one cardinality is just a degenerate case of another usually picks the wrong defaults for at least one of them.
-- *Granularity* — items in a collection, sub-items inside an item (cells in a row), content inside an item (text in a cell). Each granularity layer can hold its own selection, and they have to compose without colliding.
-- *Persistence scope* — does the selection survive scrolling, filtering, sorting, paging, navigation, refresh? Each "yes" raises a coherence question that has to be answered explicitly.
-- *Visibility* — explicit (checkboxes always present), implicit (highlight only, no resting affordance), or mode-based (an edit-mode toggle reveals checkboxes). The trade is discoverability against visual cost.
-- *Input modality* — pointer (click, shift+click, ctrl+click, drag-rectangle), keyboard (shift+arrow, ctrl+a, space), touch (long-press, edit mode), assistive technology. A selection pattern that only works in one modality is broken; the gesture grammars have to map onto the same underlying state.
+- Cardinality — single, multi (set), range (contiguous span). These have different mental models and different input grammars
+- Granularity — items in a collection, sub-items inside an item (cells in a row), content inside an item (text in a cell). Each granularity layer can hold its own selection, and they have to compose without colliding
+- Persistence scope — does the selection survive scrolling, filtering, sorting, paging, navigation, refresh
+- Visibility — explicit (checkboxes always present), implicit (highlight only, no resting affordance), or mode-based (an edit-mode toggle reveals checkboxes)
+- Input modality — pointer (click, shift+click, ctrl+click, drag-rectangle), keyboard (shift+arrow, ctrl+a, space), touch (long-press, edit mode), assistive technology
 
 ## Cardinality
 
@@ -29,18 +29,12 @@ The "current item" model. The actor picks one thing; picking another replaces th
 
 Non-contiguous, additive. The actor builds up a set by ticking checkboxes or modifier-clicking. The set has no internal order beyond insertion; each item is in or out independently of the others.
 
-Multi-selection is where most of the design pressure on [action bars](../?path=/docs/actions-coordination-action-bar--docs) comes from: the action set is a function of the selected set, and operations that apply to one item but not to many (or vice versa) have to disable or disappear as the count changes.
-
-The same multi-cardinality model shows up inside a [combobox](../?path=/docs/operations-combobox--docs) when the value being committed is itself a set — filter value pickers and tag selectors are the canonical cases. The substrate is identical (popup listbox, type-to-narrow, commit-to-set); only the cardinality changes.
-
-#### Ambient feedback for the selected set
-
-Once selection counts climb past one or two, the count alone stops being legible — the actor needs to see *what* is in the set, not just how many. Two common surfaces:
+#### Feedback for the selected set
 
 - *Inline state on the items themselves* — checkmarks, tick rows, highlight on selected rows. Cheap, but invisible the moment the actor scrolls past the selection.
-- *Chip rendering elsewhere on the canvas* — selected items rendered as removable chips in a header strip, side panel, or toolbar. Survives scroll, doubles as a remove-from-selection affordance, but costs layout.
+- *Chip rendering elsewhere in the UI* — selected items rendered as removable chips in a header strip, side panel, or toolbar. Survives scroll, doubles as a remove-from-selection affordance, but costs layout.
 
-The chip strip earns its weight when the selection is intended to outlive the current view (e.g. building up a set across paged or filtered results). The list-only feedback is fine when the selection is consumed immediately, in-view.
+The chip is worth it when the selection is intended to outlive the current view (e.g. building up a set across paged or filtered results). The list-only feedback is fine when the selection is acted on immediately.
 
 #### Select all / Clear all threshold
 
@@ -70,25 +64,23 @@ Text inside an item, regions of an image, ranges of time on a timeline. The mech
 
 ## Cross-view persistence
 
-When the actor selects 12 rows and then sorts the table, are the same 12 still selected? When they filter, do filtered-out items remain in the selection set? When they page forward, does the selection from page 1 survive? Three coherent answers exist:
+When the actor selects 12 rows and then sorts the table, are the same 12 still selected? When they filter, do filtered-out items remain in the selection set? When they page forward, does the selection from page 1 survive? Some options:
 
-- *Selection lives with the viewport* — anything not currently visible is silently removed from the selection. Simple to implement, easy to reason about, but loses the actor's commitment the moment they look away. Acceptable when selections are short-lived and small.
-- *Selection lives with the data* — selected items persist regardless of whether they're currently visible. The actor's commitment is honoured, but they may end up acting on items they can't see. This requires showing the actor that off-screen items are still in the selection ("12 selected, 8 not in current view"), or it becomes a footgun.
-- *Selection lives with the data, filter narrows the scope of action* — selected items persist, but operations apply only to the visible intersection. Honours commitment without acting on the invisible. The most defensible choice for most cases, and the hardest to implement coherently.
+- Selection lives with the viewport — anything not currently visible is silently removed from the selection. Simple to implement, easy to reason about, but loses the actor's commitment the moment they look away. Acceptable when selections are short-lived and small.
+- Selection lives with the data — selected items persist regardless of whether they're currently visible. The actor's commitment is honoured, but they may end up acting on items they can't see. This requires showing the actor that off-screen items are still in the selection ("12 selected, 8 not in current view"), or it becomes a footgun.
+- Selection lives with the data, filter narrows the scope of action — selected items persist, but operations apply only to the visible intersection. Honours commitment without acting on the invisible. The most defensible choice for most cases, and the hardest to implement coherently.
 
 ## "Select all" under filtering and paging
 
 When 50 of 10,000 items are visible and the actor clicks the master checkbox, what does it mean?
 
-- *All visible* — selects the 50 on screen. Predictable but often not what the actor wants.
-- *All matching* — selects all 10,000 that match the current filter. What the actor probably wants, but invisible to them; needs explicit confirmation.
-- *All in collection* — selects all items in the underlying collection regardless of filter. Almost never what the actor wants and usually a bug.
+- All visible — selects the 50 on screen. Predictable but often not what the actor wants.
+- All matching — selects all 10,000 that match the current filter. What the actor probably wants, but invisible to them; needs explicit confirmation.
+- All in collection — selects all items in the underlying collection regardless of filter. Almost never what the actor wants and usually a bug.
 
 A go-to solution is to select the visible view first, then offer a follow-up affordance ("Select all 1,234 items") that escalates to the matching set. Two-step opt-in: the actor sees the consequence of the smaller commitment before being offered the larger one.
 
-<Canvas>
-  <Story of={SelectionStories.SelectAllAffordance} />
-</Canvas>
+<Story of={SelectionStories.SelectAllAffordance} />
 
 ## Visibility and discoverability
 
@@ -96,16 +88,12 @@ How does the actor learn that items are selectable in the first place?
 
 - *Always-visible checkboxes* — maximum discoverability, maximum visual noise. Appropriate when selection is a primary capability of the view (inboxes, file managers).
 
-<Canvas>
-  <Story of={SelectionStories.InlineCheckboxes} />
-</Canvas>
+<Story of={SelectionStories.InlineCheckboxes} />
 
 - *Hover-revealed checkboxes* — checkboxes appear on row hover, persist when selected. Reduces visual noise without hiding the affordance entirely. Doesn't work on touch.
 - *Mode-based selection* — an explicit select/edit toggle reveals checkboxes. Common on touch surfaces where hover doesn't exist, and on content-first views where always-on selection would dominate the layout.
 
-<Canvas>
-  <Story of={SelectionStories.ModeBasedReveal} />
-</Canvas>
+<Story of={SelectionStories.ModeBasedReveal} />
 
 - *Implicit selection through pointer gestures* — no checkboxes; click-to-select, shift+click for range, `ctrl`+`click` for set.
 

--- a/src/stories/actions/coordination/Selection.stories.tsx
+++ b/src/stories/actions/coordination/Selection.stories.tsx
@@ -1,0 +1,198 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState, useRef, useEffect } from "react";
+import projectsData from "../../data/projects.json" with { type: "json" };
+import 'iconify-icon';
+import '../../jsx-types';
+
+interface Project {
+  id: string;
+  name: string;
+  icon: string;
+}
+
+const projects = projectsData as Project[];
+const TOTAL_MATCHING = 1234;
+
+const meta = {
+  title: "Actions/Coordination/Selection",
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+function useListMultiSelect() {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const listRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const handler = (e: Event) => {
+      const event = e as CustomEvent<{ item: HTMLElement }>;
+      const id = event.detail.item.getAttribute('data-value');
+      if (!id) return;
+      setSelected(prev => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+    };
+    list.addEventListener('pp-select', handler);
+    return () => list.removeEventListener('pp-select', handler);
+  }, []);
+
+  return { selected, setSelected, listRef };
+}
+
+export const InlineCheckboxes: Story = {
+  render: () => {
+    const { selected, listRef } = useListMultiSelect();
+
+    return (
+      <div className="flow" style={{ width: '320px' }}>
+        <p className="muted">{selected.size} selected</p>
+        <pp-list ref={listRef} multiselectable>
+          {projects.map(item => (
+            <pp-list-item
+              key={item.id}
+              type="checkbox"
+              data-value={item.id}
+              checked={selected.has(item.id)}
+            >
+              <iconify-icon icon={item.icon} slot="prefix" />
+              {item.name}
+            </pp-list-item>
+          ))}
+        </pp-list>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Always-visible checkboxes. Maximum discoverability, appropriate when selection is a primary capability of the view (inboxes, file managers, bulk-edit lists).'
+      }
+    }
+  }
+};
+
+export const ModeBasedReveal: Story = {
+  render: () => {
+    const [editing, setEditing] = useState(false);
+    const { selected, setSelected, listRef } = useListMultiSelect();
+
+    const exitMode = () => {
+      setEditing(false);
+      setSelected(new Set());
+    };
+
+    return (
+      <div className="flow" style={{ width: '320px' }}>
+        <div className="inline-flow">
+          {editing ? (
+            <>
+              <span className="muted">{selected.size} selected</span>
+              <button className="button button--plain" onClick={exitMode}>Done</button>
+            </>
+          ) : (
+            <>
+              <span className="muted">{projects.length} projects</span>
+              <button className="button button--plain" onClick={() => setEditing(true)}>Select</button>
+            </>
+          )}
+        </div>
+        <pp-list ref={listRef} multiselectable={editing || undefined}>
+          {projects.map(item => (
+            <pp-list-item
+              key={item.id}
+              type={editing ? 'checkbox' : undefined}
+              data-value={item.id}
+              checked={editing && selected.has(item.id)}
+            >
+              <iconify-icon icon={item.icon} slot="prefix" />
+              {item.name}
+            </pp-list-item>
+          ))}
+        </pp-list>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A "Select" toggle reveals checkboxes. Trades discoverability for visual quietness; common on touch surfaces and content-first views where always-on selection would dominate the layout.'
+      }
+    }
+  }
+};
+
+export const SelectAllAffordance: Story = {
+  render: () => {
+    const { selected, setSelected, listRef } = useListMultiSelect();
+    const [escalated, setEscalated] = useState(false);
+
+    const allVisibleIds = projects.map(i => i.id);
+    const allVisibleSelected = allVisibleIds.every(id => selected.has(id));
+    const visibleCount = projects.length;
+
+    const selectAllVisible = () => {
+      setSelected(new Set(allVisibleIds));
+      setEscalated(false);
+    };
+
+    const clearSelection = () => {
+      setSelected(new Set());
+      setEscalated(false);
+    };
+
+    const summary = escalated
+      ? `All ${TOTAL_MATCHING.toLocaleString()} matching items selected`
+      : selected.size > 0
+        ? `${selected.size} of ${visibleCount} on this page selected`
+        : `Showing ${visibleCount} of ${TOTAL_MATCHING.toLocaleString()}`;
+
+    return (
+      <div className="flow" style={{ width: '420px' }}>
+        <div className="inline-flow">
+          <span className="muted">{summary}</span>
+          {selected.size > 0 || escalated ? (
+            <button className="button button--plain" onClick={clearSelection}>Clear</button>
+          ) : (
+            <button className="button button--plain" onClick={selectAllVisible}>Select all visible</button>
+          )}
+        </div>
+        {allVisibleSelected && !escalated && (
+          <div className="callout">
+            <p>
+              All {visibleCount} items on this page are selected.{' '}
+              <button className="button button--plain" onClick={() => setEscalated(true)}>
+                Select all {TOTAL_MATCHING.toLocaleString()} matching items
+              </button>
+            </p>
+          </div>
+        )}
+        <pp-list ref={listRef} multiselectable>
+          {projects.map(item => (
+            <pp-list-item
+              key={item.id}
+              type="checkbox"
+              data-value={item.id}
+              checked={escalated || selected.has(item.id)}
+            >
+              <iconify-icon icon={item.icon} slot="prefix" />
+              {item.name}
+            </pp-list-item>
+          ))}
+        </pp-list>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'When the visible set is fully selected, an escalation affordance ("Select all 1,234 matching") appears. Honours the actor\'s commitment without acting on the invisible until they explicitly opt in.'
+      }
+    }
+  }
+};

--- a/src/stories/actions/seeking/CommandMenu.mdx
+++ b/src/stories/actions/seeking/CommandMenu.mdx
@@ -28,6 +28,7 @@ Can also be used to support local functions, e.g. in [filters](../?path=/docs/ac
 
 ### Precursors
 
+- [Combobox](../?path=/docs/operations-combobox--docs) — the mechanism this pattern builds on; `src/components/combobox/` drives the text input, filtered list, and keyboard model
 - *Search* establishes user familiarity with typing to filter results, setting expectations that input fields serve navigation and filtering tasks.
 - A command palette often extends or consolidates *keyboard shortcut* functionality, making them easier to discover and use.
 - [Keyboard key](../?path=/docs/operations-keyboard-key--docs)

--- a/src/stories/actions/seeking/CommandMenu.tsx
+++ b/src/stories/actions/seeking/CommandMenu.tsx
@@ -1,11 +1,13 @@
 import { useMemo, useCallback, useEffect } from 'react'
 
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
+  Combobox,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "../../../components/combobox";
+import {
   AIFallbackHandler,
   useAICommand,
   type AICommandResult
@@ -105,14 +107,14 @@ function CommandMenu({ onClose }: { onClose?: () => void } = {}) {
 
   return (
     <>
-      <Command label="Command menu" shouldFilter={false} onEscape={actions.handleEscape}>
-        <CommandInput
+      <Combobox label="Command menu" shouldFilter={false} onEscape={actions.handleEscape}>
+        <ComboboxInput
           placeholder={placeholder}
           value={state.searchInput}
           onValueChange={actions.updateSearch}
           ref={inputRef}
         />
-        <CommandList>
+        <ComboboxList>
           {!hasResults && (
             <AIFallbackHandler
               searchInput={state.searchInput}
@@ -135,31 +137,31 @@ function CommandMenu({ onClose }: { onClose?: () => void } = {}) {
           {hasResults && (
             <>
               {state.mode === 'global' && filteredRecentItems.length > 0 && (
-                <CommandGroup heading="Recent">
+                <ComboboxGroup heading="Recent">
                   {filteredRecentItems.map((item) => (
-                    <CommandItem key={item.id}>
+                    <ComboboxItem key={item.id}>
                       <iconify-icon icon={item.icon as string} slot="prefix"></iconify-icon>
                       {item.name}
-                    </CommandItem>
+                    </ComboboxItem>
                   ))}
-                </CommandGroup>
+                </ComboboxGroup>
               )}
 
               {state.mode === 'contextual' ? (
-                <CommandGroup>
+                <ComboboxGroup>
                   {results.contextualItems?.map((action) => (
-                    <CommandItem key={action.id} onSelect={() => actions.selectChild(action)}>
+                    <ComboboxItem key={action.id} onSelect={() => actions.selectChild(action)}>
                       <iconify-icon icon={action.icon as string} slot="prefix"></iconify-icon>
                       {action.name}
-                    </CommandItem>
+                    </ComboboxItem>
                   ))}
-                </CommandGroup>
+                </ComboboxGroup>
               ) : (
                 <>
                   {results.parents.length > 0 && (
-                    <CommandGroup heading="Commands">
+                    <ComboboxGroup heading="Commands">
                       {results.parents.map((command) => (
-                        <CommandItem key={command.id} onSelect={() => actions.selectContext(command)}>
+                        <ComboboxItem key={command.id} onSelect={() => actions.selectContext(command)}>
                           <iconify-icon icon={command.icon as string} slot="prefix"></iconify-icon>
                           {command.name}
                           {command.shortcut && (
@@ -169,27 +171,27 @@ function CommandMenu({ onClose }: { onClose?: () => void } = {}) {
                               ))}
                             </span>
                           )}
-                        </CommandItem>
+                        </ComboboxItem>
                       ))}
-                    </CommandGroup>
+                    </ComboboxGroup>
                   )}
 
                   {results.children.length > 0 && (
-                    <CommandGroup heading="Actions">
+                    <ComboboxGroup heading="Actions">
                       {results.children.map(({ parent, child }) => (
-                        <CommandItem key={`${parent.id}-${child.id}`} onSelect={() => actions.selectChild(child, parent)}>
+                        <ComboboxItem key={`${parent.id}-${child.id}`} onSelect={() => actions.selectChild(child, parent)}>
                           <iconify-icon icon={child.icon as string} slot="prefix"></iconify-icon>
                           {parent.name} {child.name}
-                        </CommandItem>
+                        </ComboboxItem>
                       ))}
-                    </CommandGroup>
+                    </ComboboxGroup>
                   )}
                 </>
               )}
             </>
           )}
-        </CommandList>
-      </Command>
+        </ComboboxList>
+      </Combobox>
     </>
   )
 }

--- a/src/stories/actions/seeking/DataView/FilterControls.tsx
+++ b/src/stories/actions/seeking/DataView/FilterControls.tsx
@@ -2,15 +2,17 @@ import React from 'react';
 import { Icon } from '@iconify/react';
 import { nanoid } from 'nanoid';
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
+  Combobox,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "../../../../components/combobox";
+import {
   AIFallbackHandler,
   useAICommand,
   type AICommandResult,
-  type AICommandItem
+  type AIComboboxItem
 } from "../../../../components/command-menu";
 import { AnimateChangeInHeight } from "../../../../components/filter/animate-change-in-height";
 import { useHierarchicalNavigation } from '../../../../hooks/useHierarchicalNavigation';
@@ -97,7 +99,7 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
   });
 
   const handleApplyAIFilters = React.useCallback((result: AICommandResult) => {
-    const newFilters = result.suggestedItems.map((item: AICommandItem) => {
+    const newFilters = result.suggestedItems.map((item: AIComboboxItem) => {
       if (!item.metadata) throw new Error('Invalid AI command item: missing metadata');
       return {
         id: nanoid(),
@@ -141,14 +143,14 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
 
         <div>
           <AnimateChangeInHeight>
-            <Command shouldFilter={false} onEscape={actions.handleEscape}>
-              <CommandInput
+            <Combobox shouldFilter={false} onEscape={actions.handleEscape}>
+              <ComboboxInput
                 placeholder={placeholder}
                 value={state.searchInput}
                 onValueChange={actions.updateSearch}
                 ref={inputRef}
               />
-              <CommandList>
+              <ComboboxList>
                 {!hasResults && state.searchInput.length >= 2 && (
                   <AIFallbackHandler
                     searchInput={state.searchInput}
@@ -162,41 +164,41 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
                 )}
 
                 {state.mode === 'contextual' ? (
-                  <CommandGroup>
+                  <ComboboxGroup>
                     {results.contextualItems?.map((filterValue) => (
-                      <CommandItem key={filterValue.id} onSelect={() => actions.selectChild(filterValue)}>
+                      <ComboboxItem key={filterValue.id} onSelect={() => actions.selectChild(filterValue)}>
                         <iconify-icon icon={filterValue.icon} slot="prefix" />
                         <span>{filterValue.name}</span>
-                      </CommandItem>
+                      </ComboboxItem>
                     ))}
-                  </CommandGroup>
+                  </ComboboxGroup>
                 ) : (
                   <>
                     {results.parents.length > 0 && (
-                      <CommandGroup>
+                      <ComboboxGroup>
                         {results.parents.map((filterType) => (
-                          <CommandItem key={filterType.id} onSelect={() => actions.selectContext(filterType)}>
+                          <ComboboxItem key={filterType.id} onSelect={() => actions.selectContext(filterType)}>
                             <iconify-icon icon={filterType.icon} slot="prefix" />
                             {filterType.name}
-                          </CommandItem>
+                          </ComboboxItem>
                         ))}
-                      </CommandGroup>
+                      </ComboboxGroup>
                     )}
 
                     {results.children.length > 0 && (
-                      <CommandGroup>
+                      <ComboboxGroup>
                         {results.children.map(({ parent, child }) => (
-                          <CommandItem key={`${parent.id}-${child.id}`} onSelect={() => actions.selectChild(child, parent)}>
+                          <ComboboxItem key={`${parent.id}-${child.id}`} onSelect={() => actions.selectChild(child, parent)}>
                             <iconify-icon icon={child.icon} slot="prefix" />
                             <span>{child.name}</span>
-                          </CommandItem>
+                          </ComboboxItem>
                         ))}
-                      </CommandGroup>
+                      </ComboboxGroup>
                     )}
                   </>
                 )}
-              </CommandList>
-            </Command>
+              </ComboboxList>
+            </Combobox>
           </AnimateChangeInHeight>
         </div>
       </pp-dropdown>

--- a/src/stories/actions/seeking/DataView/ProductFilterValueDropdown.tsx
+++ b/src/stories/actions/seeking/DataView/ProductFilterValueDropdown.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '../../../../components/command-menu/command';
+  Combobox,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from '../../../../components/combobox';
 import { AnimateChangeInHeight } from '../../../../components/filter/animate-change-in-height';
 import { useDropdownState } from '../../../../components/filter/hooks/use-dropdown-state';
 import { ProductFilterType, ProductFilterCategory } from './ProductFilterTypes';
@@ -29,7 +29,7 @@ export const ProductFilterValueDropdown: React.FC<ProductFilterValueDropdownProp
 }) => {
   const {
     commandInput,
-    setCommandInput,
+    setComboboxInput,
     commandInputRef,
     dropdownRef,
     handleDropdownShow,
@@ -89,35 +89,35 @@ export const ProductFilterValueDropdown: React.FC<ProductFilterValueDropdownProp
 
       <div>
         <AnimateChangeInHeight>
-          <Command>
-            <CommandInput
+          <Combobox>
+            <ComboboxInput
               placeholder={filterType}
               className="h-9"
               value={commandInput}
               onInputCapture={(e) => {
-                setCommandInput(e.currentTarget.value);
+                setComboboxInput(e.currentTarget.value);
               }}
               ref={commandInputRef}
             />
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup>
+            <ComboboxList>
+              <ComboboxEmpty>No results found.</ComboboxEmpty>
+              <ComboboxGroup>
                 {filterValues.map((value) => (
-                  <CommandItem
+                  <ComboboxItem
                     key={value}
                     checked={true}
                     onSelect={() => handleValueRemove(value)}
                   >
                     <iconify-icon icon={getIconForValue(value)} slot="prefix" />
                     {getDisplayName(value)}
-                  </CommandItem>
+                  </ComboboxItem>
                 ))}
-              </CommandGroup>
+              </ComboboxGroup>
               {nonSelectedFilterValues?.length > 0 && (
                 <>
-                  <CommandGroup>
+                  <ComboboxGroup>
                     {nonSelectedFilterValues.map((option) => (
-                      <CommandItem
+                      <ComboboxItem
                         key={option.value}
                         value={option.name}
                         checked={false}
@@ -127,13 +127,13 @@ export const ProductFilterValueDropdown: React.FC<ProductFilterValueDropdownProp
                         <span>
                           {option.name}
                         </span>
-                      </CommandItem>
+                      </ComboboxItem>
                     ))}
-                  </CommandGroup>
+                  </ComboboxGroup>
                 </>
               )}
-            </CommandList>
-          </Command>
+            </ComboboxList>
+          </Combobox>
         </AnimateChangeInHeight>
       </div>
     </pp-dropdown>

--- a/src/stories/actions/seeking/Filtering.mdx
+++ b/src/stories/actions/seeking/Filtering.mdx
@@ -46,6 +46,7 @@ If that fails, users can delegate filtering to a [bot](../?path=/docs/activities
 
 - Typically placed in a [toolbar](../?path=/docs/actions-coordination-toolbar--docs)
 - Depends on [command menu](../?path=/docs/actions-seeking-command-menu--docs) for the local search through attributes and values.
+- [Combobox](../?path=/docs/operations-combobox--docs) — the value-picker inside each active filter chip uses a combobox to narrow available values
 
 
 ### Complementary

--- a/src/stories/actions/seeking/Filtering.tsx
+++ b/src/stories/actions/seeking/Filtering.tsx
@@ -3,15 +3,17 @@ import { nanoid } from "nanoid";
 import { Icon } from '@iconify/react';
 
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
+  Combobox,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "../../../components/combobox";
+import {
   AIFallbackHandler,
   useAICommand,
   type AICommandResult,
-  type AICommandItem
+  type AIComboboxItem
 } from "../../../components/command-menu";
 import { AnimateChangeInHeight } from "../../../components/filter/animate-change-in-height";
 import Filters from "../../../components/filter/filters";
@@ -142,7 +144,7 @@ export function FilteringDemo({
   });
 
   const handleApplyAIFilters = React.useCallback((result: AICommandResult) => {
-    const newFilters = result.suggestedItems.map((item: AICommandItem) => {
+    const newFilters = result.suggestedItems.map((item: AIComboboxItem) => {
       if (!item.metadata) throw new Error('Invalid AI command item: missing metadata');
       return {
         id: nanoid(),
@@ -187,14 +189,14 @@ export function FilteringDemo({
 
         <div>
           <AnimateChangeInHeight>
-            <Command shouldFilter={false} onEscape={actions.handleEscape}>
-              <CommandInput
+            <Combobox shouldFilter={false} onEscape={actions.handleEscape}>
+              <ComboboxInput
                 placeholder={placeholder}
                 value={state.searchInput}
                 onValueChange={actions.updateSearch}
                 ref={inputRef}
               />
-              <CommandList>
+              <ComboboxList>
                 {!hasResults && state.searchInput.length >= 2 && (
                   <AIFallbackHandler
                     searchInput={state.searchInput}
@@ -208,41 +210,41 @@ export function FilteringDemo({
                 )}
 
                 {state.mode === 'contextual' ? (
-                  <CommandGroup>
+                  <ComboboxGroup>
                     {results.contextualItems?.map((filterValue) => (
-                      <CommandItem key={filterValue.id} onSelect={() => actions.selectChild(filterValue)}>
+                      <ComboboxItem key={filterValue.id} onSelect={() => actions.selectChild(filterValue)}>
                         <iconify-icon icon={filterValue.icon} slot="prefix" />
                         <span>{filterValue.name}</span>
-                      </CommandItem>
+                      </ComboboxItem>
                     ))}
-                  </CommandGroup>
+                  </ComboboxGroup>
                 ) : (
                   <>
                     {results.parents.length > 0 && (
-                      <CommandGroup>
+                      <ComboboxGroup>
                         {results.parents.map((filterType) => (
-                          <CommandItem key={filterType.id} onSelect={() => actions.selectContext(filterType)}>
+                          <ComboboxItem key={filterType.id} onSelect={() => actions.selectContext(filterType)}>
                             <iconify-icon icon={filterType.icon} slot="prefix" />
                             {filterType.name}
-                          </CommandItem>
+                          </ComboboxItem>
                         ))}
-                      </CommandGroup>
+                      </ComboboxGroup>
                     )}
 
                     {results.children.length > 0 && (
-                      <CommandGroup>
+                      <ComboboxGroup>
                         {results.children.map(({ parent, child }) => (
-                          <CommandItem key={`${parent.id}-${child.id}`} onSelect={() => actions.selectChild(child, parent)}>
+                          <ComboboxItem key={`${parent.id}-${child.id}`} onSelect={() => actions.selectChild(child, parent)}>
                             <iconify-icon icon={child.icon} slot="prefix" />
                             <span>{child.name}</span>
-                          </CommandItem>
+                          </ComboboxItem>
                         ))}
-                      </CommandGroup>
+                      </ComboboxGroup>
                     )}
                   </>
                 )}
-              </CommandList>
-            </Command>
+              </ComboboxList>
+            </Combobox>
           </AnimateChangeInHeight>
         </div>
       </pp-dropdown>

--- a/src/stories/actions/seeking/Searching.mdx
+++ b/src/stories/actions/seeking/Searching.mdx
@@ -57,6 +57,7 @@ Search shouldn't destroy context. It should be easily reversible, returning the 
 - [Filtering](../?path=/docs/actions-seeking-filtering--docs): Often used *after* a search to refine results. In AI-search, filters are the *output* of the search query.
 - [Prompt](../?path=/docs/activities-prompt--docs): Modern search inputs are evolving into Prompt interfaces, accepting instructions alongside keywords.
 - [Autocomplete](../?path=/docs/operations-autocomplete--docs): real-time narrowing of query suggestions as the actor types.
+- [Combobox](../?path=/docs/operations-combobox--docs) — the entry-phase mechanism for instant-results variants (popover/dropdown); the search input binding follows the combobox contract.
 - [Suggestion](../?path=/docs/actions-application-suggestion--docs): "Did you mean?" and related patterns that guide query formulation.
 
 ### Follow-ups

--- a/src/stories/data/components.json
+++ b/src/stories/data/components.json
@@ -43,7 +43,7 @@
     "id": "CMP-BAT-002",
     "name": "Battery Management System",
     "type": "sub_assembly",
-    "icon": "ph:circuit-board",
+    "icon": "ph:circle-dashed",
     "description": "PCB controlling battery charging and safety",
     "searchableText": "battery management system bms pcb charging safety circuit",
     "metadata": {

--- a/src/stories/operations/Autocomplete.mdx
+++ b/src/stories/operations/Autocomplete.mdx
@@ -23,7 +23,7 @@ Part of the [assisted task completion](../?path=/docs/actions-application-assist
 ### Precursors
 
 - [Input](../?path=/docs/operations-input--docs) — the primitive that autocomplete builds on
-- [Combobox](../?path=/docs/operations-combobox--docs) — the WAI-ARIA contract this pattern builds on: text input + popup listbox + keyboard model
+- [Combobox](../?path=/docs/operations-combobox--docs) — component this pattern builds on
 - [Good defaults](../?path=/docs/operations-good-defaults--docs) — pre-populating values before the actor starts typing
 
 ### Complementary

--- a/src/stories/operations/Autocomplete.mdx
+++ b/src/stories/operations/Autocomplete.mdx
@@ -1,15 +1,16 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Canvas, Story, Meta } from '@storybook/addon-docs/blocks';
+import * as AutocompleteStories from './Autocomplete.stories.tsx';
 import { profile } from './Autocomplete.profile';
 
-<Meta
-  title="Operations/Autocomplete"
-  tags={['activity-level:operation', 'atomic:pattern', 'role:pattern', 'mediation:individual']}/>
+<Meta of={ AutocompleteStories } tags={['activity-level:operation', 'atomic:pattern', 'role:pattern', 'mediation:individual']} />
 
 > 🙂 **Fun meter: 2/5**. Dependency.
 
 # Autocomplete
 
 Predicting and suggesting completions for a value the actor is actively typing, so they can pick from a narrowing set of options instead of finishing the thought themselves.
+
+<Story of={ AutocompleteStories.Default } />
 
 Part of the [assisted task completion](../?path=/docs/actions-application-assisted-task-completion--docs) spectrum, at the most reactive end — the system takes almost no initiative here.
 

--- a/src/stories/operations/Autocomplete.mdx
+++ b/src/stories/operations/Autocomplete.mdx
@@ -23,6 +23,7 @@ Part of the [assisted task completion](../?path=/docs/actions-application-assist
 ### Precursors
 
 - [Input](../?path=/docs/operations-input--docs) — the primitive that autocomplete builds on
+- [Combobox](../?path=/docs/operations-combobox--docs) — the WAI-ARIA contract this pattern builds on: text input + popup listbox + keyboard model
 - [Good defaults](../?path=/docs/operations-good-defaults--docs) — pre-populating values before the actor starts typing
 
 ### Complementary

--- a/src/stories/operations/Autocomplete.stories.tsx
+++ b/src/stories/operations/Autocomplete.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import {
+  Combobox,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "../../components/combobox";
+import { recentItems, documents, tasks } from '../data';
+import 'iconify-icon';
+import '../../jsx-types';
+
+const meta = {
+  title: "Operations/Autocomplete",
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+const recentSearches = recentItems.map(r => r.name);
+const popularSearches = [
+  ...documents.map(d => d.name),
+  ...tasks.map(t => t.title),
+];
+
+export const Default: Story = {
+  render: () => {
+    const [query, setQuery] = useState('');
+    const [open, setOpen] = useState(false);
+
+    const select = (value: string) => {
+      setQuery(value);
+      setOpen(false);
+    };
+
+    return (
+      <div style={{ width: '320px' }}>
+        <Combobox>
+          <ComboboxInput
+            value={query}
+            onValueChange={setQuery}
+            onFocus={() => setOpen(true)}
+            placeholder="Search…"
+          />
+          {open && (
+            <ComboboxList>
+              {!query && (
+                <ComboboxGroup heading="Recent">
+                  {recentSearches.map((s) => (
+                    <ComboboxItem key={s} value={s} onSelect={select}>
+                      {s}
+                    </ComboboxItem>
+                  ))}
+                </ComboboxGroup>
+              )}
+              {query.length >= 2 && (
+                <ComboboxGroup>
+                  {popularSearches.map((s) => (
+                    <ComboboxItem key={s} value={s} onSelect={select}>
+                      {s}
+                    </ComboboxItem>
+                  ))}
+                </ComboboxGroup>
+              )}
+            </ComboboxList>
+          )}
+        </Combobox>
+      </div>
+    );
+  },
+};

--- a/src/stories/operations/Combobox.mdx
+++ b/src/stories/operations/Combobox.mdx
@@ -14,17 +14,6 @@ A text input paired with a popup listbox: the actor types to narrow candidates, 
   <Story of={ ComboboxStories.Default } />
 </Canvas>
 
-## The WAI-ARIA contract
-
-The [WAI-ARIA APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) specifies four invariants that `src/components/combobox/` realises via thin wrappers over [`cmdk`](https://www.npmjs.com/package/cmdk):
-
-1. **Text input** — typing filters the popup content
-2. **Popup listbox** — opens on focus or first keystroke; dismissed after selection or Escape
-3. **Selection commit** — Enter or pointer click activates an item, closes the popup, and writes the value
-4. **Keyboard model** — Arrow Up/Down navigate items; Home/End jump to list bounds; Escape cancels
-
-The exported primitives are: `Combobox`, `ComboboxInput`, `ComboboxList`, `ComboboxEmpty`, `ComboboxGroup`, `ComboboxItem`.
-
 ## Checked items
 
 `ComboboxItem` accepts a `checked` prop for multi-select use cases, where selections accumulate before the actor dismisses the popup. The filter value picker in [Filtering](../?path=/docs/actions-seeking-filtering--docs) uses this variant.
@@ -64,7 +53,7 @@ The exported primitives are: `Combobox`, `ComboboxInput`, `ComboboxList`, `Combo
 
 ## Resources & references
 
-- [WAI-ARIA APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
-- [`cmdk`](https://github.com/dip/cmdk) — React component library implementing the WAI-ARIA combobox pattern, which this component wraps
-- [Open UI — Combobox research](https://open-ui.org/components/combobox.research/)
+- [WAI-ARIA APG pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+- [`cmdk`](https://github.com/dip/cmdk) — React component library which this component wraps
+- Open UI / [Research](https://open-ui.org/components/combobox.research/) & [Explainer](https://open-ui.org/components/combobox.explainer/)
 - Smashing Magazine — [Combobox vs Multiselect vs Listbox](https://www.smashingmagazine.com/2026/02/combobox-vs-multiselect-vs-listbox/)

--- a/src/stories/operations/Combobox.mdx
+++ b/src/stories/operations/Combobox.mdx
@@ -1,0 +1,71 @@
+import { Canvas, Story, Meta } from '@storybook/addon-docs/blocks';
+import * as ComboboxStories from './Combobox.stories.tsx';
+import { profile } from './Combobox.profile';
+
+<Meta of={ ComboboxStories } tags={['activity-level:operation', 'atomic:pattern', 'role:component', 'mediation:individual']} />
+
+> 🔧 **Fun meter: 2/5**. Mechanism, not a move. One contract — type to narrow, commit on activation — spans [Command menu](../?path=/docs/actions-seeking-command-menu--docs) (invoke), [Filtering](../?path=/docs/actions-seeking-filtering--docs) (narrow), and [Autocomplete](../?path=/docs/operations-autocomplete--docs) (suggest) without changing shape. The interesting questions live in those consuming patterns.
+
+# Combobox
+
+A text input paired with a popup listbox: the actor types to narrow candidates, then activates one to commit.
+
+<Canvas>
+  <Story of={ ComboboxStories.Default } />
+</Canvas>
+
+## The WAI-ARIA contract
+
+The [WAI-ARIA APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) specifies four invariants that `src/components/combobox/` realises via thin wrappers over [`cmdk`](https://www.npmjs.com/package/cmdk):
+
+1. **Text input** — typing filters the popup content
+2. **Popup listbox** — opens on focus or first keystroke; dismissed after selection or Escape
+3. **Selection commit** — Enter or pointer click activates an item, closes the popup, and writes the value
+4. **Keyboard model** — Arrow Up/Down navigate items; Home/End jump to list bounds; Escape cancels
+
+The exported primitives are: `Combobox`, `ComboboxInput`, `ComboboxList`, `ComboboxEmpty`, `ComboboxGroup`, `ComboboxItem`.
+
+## Checked items
+
+`ComboboxItem` accepts a `checked` prop for multi-select use cases, where selections accumulate before the actor dismisses the popup. The filter value picker in [Filtering](../?path=/docs/actions-seeking-filtering--docs) uses this variant.
+
+<Story of={ ComboboxStories.Checked } />
+
+## Grouped
+
+`ComboboxGroup` divides the listbox into labelled sections without adding interaction cost. Useful when the option set spans multiple categories.
+
+<Story of={ ComboboxStories.Grouped } />
+
+## Design considerations
+
+- Pass `shouldFilter={false}` when the parent owns filtering — all consuming patterns in this codebase do, to support fuzzy search and server-side results.
+- Match the input placeholder to the narrowing target ("Filter by priority…") rather than a generic label. Hierarchical consumers like Command menu and Reference picker update the placeholder dynamically as context shifts.
+- `onEscape` extends `cmdk`'s default behaviour. Returning `true` signals that the consumer handled the keypress — letting hierarchical consumers navigate back a level before closing rather than always exiting.
+- Prefer a native `<select>` for short, known option sets; a combobox earns its weight only when the set is long, unfamiliar, or fetched asynchronously.
+
+## Related patterns
+
+### Containers and primitives
+
+- [`cmdk`](https://www.npmjs.com/package/cmdk) — upstream primitive this module wraps
+- [Input](../?path=/docs/operations-input--docs) — the text field half of the contract, without the popup
+- [Select](../?path=/docs/operations-select--docs) — the simpler counterpart for short, bounded sets already known to the actor
+
+### Applied in
+
+- [Command menu](../?path=/docs/actions-seeking-command-menu--docs) — the combobox contract drives hierarchical navigation and command activation
+- [Filtering](../?path=/docs/actions-seeking-filtering--docs) — each filter chip's value-picker uses a combobox to narrow available values
+- [Autocomplete](../?path=/docs/operations-autocomplete--docs) — narrowing-as-you-type is the combobox contract applied to query suggestion
+- [Searching](../?path=/docs/actions-seeking-searching--docs) — the entry phase of instant-results search (popover or dropdown variant) follows the combobox model
+
+### Follow-ups
+
+- A searchable Select built on this module, for option sets too long for native `<select>`
+
+## Resources & references
+
+- [WAI-ARIA APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+- [`cmdk`](https://github.com/pacocoursey/cmdk) — the upstream library
+- [Open UI — Combobox research](https://open-ui.org/components/combobox.research/)
+- Smashing Magazine — [Combobox vs Multiselect vs Listbox](https://www.smashingmagazine.com/2026/02/combobox-vs-multiselect-vs-listbox/)

--- a/src/stories/operations/Combobox.mdx
+++ b/src/stories/operations/Combobox.mdx
@@ -4,7 +4,7 @@ import { profile } from './Combobox.profile';
 
 <Meta of={ ComboboxStories } tags={['activity-level:operation', 'atomic:pattern', 'role:component', 'mediation:individual']} />
 
-> 🔧 **Fun meter: 2/5**. Mechanism, not a move. One contract — type to narrow, commit on activation — spans [Command menu](../?path=/docs/actions-seeking-command-menu--docs) (invoke), [Filtering](../?path=/docs/actions-seeking-filtering--docs) (narrow), and [Autocomplete](../?path=/docs/operations-autocomplete--docs) (suggest) without changing shape. The interesting questions live in those consuming patterns.
+> 🔧 **Fun meter: 2/5**. Dependency.
 
 # Combobox
 
@@ -48,7 +48,6 @@ The exported primitives are: `Combobox`, `ComboboxInput`, `ComboboxList`, `Combo
 
 ### Containers and primitives
 
-- [`cmdk`](https://www.npmjs.com/package/cmdk) — upstream primitive this module wraps
 - [Input](../?path=/docs/operations-input--docs) — the text field half of the contract, without the popup
 - [Select](../?path=/docs/operations-select--docs) — the simpler counterpart for short, bounded sets already known to the actor
 
@@ -66,6 +65,6 @@ The exported primitives are: `Combobox`, `ComboboxInput`, `ComboboxList`, `Combo
 ## Resources & references
 
 - [WAI-ARIA APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
-- [`cmdk`](https://github.com/pacocoursey/cmdk) — the upstream library
+- [`cmdk`](https://github.com/dip/cmdk) — React component library implementing the WAI-ARIA combobox pattern, which this component wraps
 - [Open UI — Combobox research](https://open-ui.org/components/combobox.research/)
 - Smashing Magazine — [Combobox vs Multiselect vs Listbox](https://www.smashingmagazine.com/2026/02/combobox-vs-multiselect-vs-listbox/)

--- a/src/stories/operations/Combobox.mdx
+++ b/src/stories/operations/Combobox.mdx
@@ -14,24 +14,23 @@ A text input paired with a popup listbox: the actor types to narrow candidates, 
   <Story of={ ComboboxStories.Default } />
 </Canvas>
 
-## Checked items
+## Multiple selection
 
-`ComboboxItem` accepts a `checked` prop for multi-select use cases, where selections accumulate before the actor dismisses the popup. The filter value picker in [Filtering](../?path=/docs/actions-seeking-filtering--docs) uses this variant.
+`TODO:` Use `multiple` with [tags](../?path=/docs/operations-tag--docs) for multi-select behavior.
 
-<Story of={ ComboboxStories.Checked } />
+## Validation
+
+`TODO:` Use the `aria-invalid` prop to make the combobox invalid.
+
+## Disabled
+
+`TODO:` Use the `disabled` prop to disable the combobox.
 
 ## Grouped
 
 `ComboboxGroup` divides the listbox into labelled sections without adding interaction cost. Useful when the option set spans multiple categories.
 
 <Story of={ ComboboxStories.Grouped } />
-
-## Design considerations
-
-- Pass `shouldFilter={false}` when the parent owns filtering — all consuming patterns in this codebase do, to support fuzzy search and server-side results.
-- Match the input placeholder to the narrowing target ("Filter by priority…") rather than a generic label. Hierarchical consumers like Command menu and Reference picker update the placeholder dynamically as context shifts.
-- `onEscape` extends `cmdk`'s default behaviour. Returning `true` signals that the consumer handled the keypress — letting hierarchical consumers navigate back a level before closing rather than always exiting.
-- Prefer a native `<select>` for short, known option sets; a combobox earns its weight only when the set is long, unfamiliar, or fetched asynchronously.
 
 ## Related patterns
 

--- a/src/stories/operations/Combobox.profile.ts
+++ b/src/stories/operations/Combobox.profile.ts
@@ -1,0 +1,9 @@
+import type { GenerativeProfile } from '../../pattern-profile';
+
+export const profile: GenerativeProfile = {
+  operatesOn:
+    'a value drawn from a long, unfamiliar, or dynamically fetched option set',
+  produces:
+    'a text input bound to a filtered popup list: type to narrow, activate to commit',
+  enacts: 'recognition over recall, economy of typing, predictable keyboard navigation',
+};

--- a/src/stories/operations/Combobox.stories.tsx
+++ b/src/stories/operations/Combobox.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj;
 
 const statusOptions = [
   { value: 'backlog', label: 'Backlog', icon: 'ph:circle' },
-  { value: 'todo', label: 'To do', icon: 'ph:circle-dotted' },
+  { value: 'todo', label: 'To do', icon: 'ph:circle-dashed' },
   { value: 'in-progress', label: 'In progress', icon: 'ph:circle-half' },
   { value: 'in-review', label: 'In review', icon: 'ph:circle-wavy' },
   { value: 'done', label: 'Done', icon: 'ph:check-circle' },

--- a/src/stories/operations/Combobox.stories.tsx
+++ b/src/stories/operations/Combobox.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import {
+  Combobox,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "../../components/combobox";
+import 'iconify-icon';
+import '../../jsx-types';
+
+const meta = {
+  title: "Operations/Combobox",
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+const statusOptions = [
+  { value: 'backlog', label: 'Backlog', icon: 'ph:circle' },
+  { value: 'todo', label: 'To do', icon: 'ph:circle-dotted' },
+  { value: 'in-progress', label: 'In progress', icon: 'ph:circle-half' },
+  { value: 'in-review', label: 'In review', icon: 'ph:circle-wavy' },
+  { value: 'done', label: 'Done', icon: 'ph:check-circle' },
+  { value: 'cancelled', label: 'Cancelled', icon: 'ph:x-circle' },
+];
+
+const priorityOptions = [
+  { value: 'urgent', label: 'Urgent', icon: 'ph:warning-octagon' },
+  { value: 'high', label: 'High', icon: 'ph:arrow-up' },
+  { value: 'medium', label: 'Medium', icon: 'ph:minus' },
+  { value: 'low', label: 'Low', icon: 'ph:arrow-down' },
+  { value: 'none', label: 'No priority', icon: 'ph:dot' },
+];
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ width: '240px' }}>
+      <Combobox>
+        <ComboboxInput placeholder="Set status…" />
+        <ComboboxList>
+          <ComboboxEmpty>No results.</ComboboxEmpty>
+          <ComboboxGroup>
+            {statusOptions.map((option) => (
+              <ComboboxItem key={option.value} value={option.label}>
+                <iconify-icon icon={option.icon} slot="prefix" />
+                {option.label}
+              </ComboboxItem>
+            ))}
+          </ComboboxGroup>
+        </ComboboxList>
+      </Combobox>
+    </div>
+  ),
+};
+
+export const Checked: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<string[]>([]);
+
+    const toggle = (value: string) =>
+      setSelected(prev =>
+        prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]
+      );
+
+    return (
+      <div style={{ width: '240px' }}>
+        <Combobox>
+          <ComboboxInput placeholder="Filter by priority…" />
+          <ComboboxList>
+            <ComboboxEmpty>No results.</ComboboxEmpty>
+            <ComboboxGroup>
+              {priorityOptions.map((option) => (
+                <ComboboxItem
+                  key={option.value}
+                  value={option.label}
+                  checked={selected.includes(option.value)}
+                  onSelect={() => toggle(option.value)}
+                >
+                  <iconify-icon icon={option.icon} slot="prefix" />
+                  {option.label}
+                </ComboboxItem>
+              ))}
+            </ComboboxGroup>
+          </ComboboxList>
+        </Combobox>
+      </div>
+    );
+  },
+};
+
+export const Grouped: Story = {
+  render: () => (
+    <div style={{ width: '240px' }}>
+      <Combobox>
+        <ComboboxInput placeholder="Search…" />
+        <ComboboxList>
+          <ComboboxEmpty>No results.</ComboboxEmpty>
+          <ComboboxGroup heading="Status">
+            {statusOptions.map((option) => (
+              <ComboboxItem key={option.value} value={option.label}>
+                <iconify-icon icon={option.icon} slot="prefix" />
+                {option.label}
+              </ComboboxItem>
+            ))}
+          </ComboboxGroup>
+          <ComboboxGroup heading="Priority">
+            {priorityOptions.map((option) => (
+              <ComboboxItem key={option.value} value={option.label}>
+                <iconify-icon icon={option.icon} slot="prefix" />
+                {option.label}
+              </ComboboxItem>
+            ))}
+          </ComboboxGroup>
+        </ComboboxList>
+      </Combobox>
+    </div>
+  ),
+};

--- a/src/stories/operations/Select.mdx
+++ b/src/stories/operations/Select.mdx
@@ -48,7 +48,7 @@ Native `<optgroup>` organises options into labelled regions without moving the i
 
 - With five or fewer choices, radios are faster and surface the whole set at once. Reach for select only when the list is long enough that collapsing it is worth the extra interaction.
 - When the set is long *or* the actor doesn't yet know what they're looking for, narrowing-as-you-type wins — see [Autocomplete](../?path=/docs/operations-autocomplete--docs). Select assumes the actor already knows the answer.
-- Multi-select is intentionally out of scope. Native `<select multiple>` is poorly supported by assistive tech and hard to discover; use checkboxes or a forthcoming combobox instead.
+- Multi-select is intentionally out of scope. Native `<select multiple>` is poorly supported by assistive tech and hard to discover; use checkboxes or a [combobox](../?path=/docs/operations-combobox--docs) instead.
 - Errors are announced with a visually-hidden "Error:" prefix and wired through `aria-describedby`, so screen readers hear the error class before the message.
 - Native keyboard behaviour (space/enter to open, arrows to navigate, home/end, typeahead, escape to close) comes for free because the control wraps a native `<select>` rather than rebuilding as an ARIA listbox.
 
@@ -65,7 +65,7 @@ Native `<optgroup>` organises options into labelled regions without moving the i
 - [Data entry](../?path=/docs/actions-application-data-entry--docs) — the broader activity select participates in.
 
 ### Follow-ups
-- A future combobox for searchable, async, or custom-rendered option sets, built on the WAI-ARIA APG combobox pattern.
+- [Combobox](../?path=/docs/operations-combobox--docs) — for searchable, async, or custom-rendered option sets, built on the WAI-ARIA APG combobox pattern.
 
 ## Resources & references
 

--- a/src/stories/operations/Select.mdx
+++ b/src/stories/operations/Select.mdx
@@ -4,7 +4,7 @@ import { profile } from './Select.profile';
 
 <Meta title="Operations/Select" of={ SelectStories } tags={['activity-level:operation', 'atomic:primitive', 'role:component', 'mediation:individual']} />
 
-> 🥱 **Fun meter: boring**. A well-trodden primitive. Included as a prerequisite for more interesting things; the interesting questions live next door in [Autocomplete](../?path=/docs/operations-autocomplete--docs) and a future combobox.
+> 🥱 **Fun meter: boring**. A well-trodden primitive. Included as a prerequisite for more interesting things.
 
 # Select
 

--- a/src/styles/cmdk.css
+++ b/src/styles/cmdk.css
@@ -21,6 +21,15 @@ pp-dialog [cmdk-root] {
   outline: none;
 }
 
+[cmdk-root]:not(:has([cmdk-list])) {
+  padding-block-end: 0;
+}
+
+[cmdk-root]:not(:has([cmdk-list])) [cmdk-input-wrapper] {
+  /* padding-block-end: 0; */
+  border-bottom: none;
+}
+
 [cmdk-input-wrapper] {
   display: flex;
   align-items: center;
@@ -82,7 +91,8 @@ pp-dialog [cmdk-root] {
   /* border-radius: var(--radius-s); */
 }
 
-[cmdk-item]:hover:not([aria-disabled="true"]) {
+[cmdk-item]:hover:not([aria-disabled="true"]),
+[cmdk-item][aria-selected="true"]:not([aria-disabled="true"]) {
   background-color: var(--c-neutral-50);
   color: var(--c-neutral-1000);
 }

--- a/src/styles/cmdk.css
+++ b/src/styles/cmdk.css
@@ -93,28 +93,27 @@ pp-dialog [cmdk-root] {
   cursor: not-allowed;
 }
 
-/* CommandItem prefix (icons) */
-[cmdk-item] .command-item__prefix:not(:empty) {
+[cmdk-item] .combobox-item__prefix:not(:empty) {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
   margin-inline-end: var(--_cmdk-spacing);
 }
 
-[cmdk-item] .command-item__prefix .icon,
-[cmdk-item] .command-item__prefix iconify-icon {
+[cmdk-item] .combobox-item__prefix .icon,
+[cmdk-item] .combobox-item__prefix iconify-icon {
   color: oklch(from var(--c-body) l c h / 0.6);
   fill: oklch(from var(--c-body) l c h / 0.6);
 }
 
-[cmdk-item] .command-item__label {
+[cmdk-item] .combobox-item__label {
   flex: 1 1 auto;
   display: inline-block;
   text-overflow: ellipsis;
   overflow: hidden;
 }
 
-[cmdk-item] .command-item__suffix {
+[cmdk-item] .combobox-item__suffix {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
@@ -122,7 +121,7 @@ pp-dialog [cmdk-root] {
   min-width: 1em;
 }
 
-[cmdk-item] .command-item__check {
+[cmdk-item] .combobox-item__check {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
@@ -131,7 +130,7 @@ pp-dialog [cmdk-root] {
   visibility: hidden;
 }
 
-[cmdk-item].command-item--checked .command-item__check {
+[cmdk-item].combobox-item--checked .combobox-item__check {
   visibility: visible;
 }
 


### PR DESCRIPTION
## Summary

This PR extracts the combobox primitives from `command-menu/command.tsx` into a new `src/components/combobox/` module with identifiers renamed from `Command*` to `Combobox*`. It also adds comprehensive documentation for selection patterns and introduces planning documents for combobox territory and dual listbox.

## Key Changes

### Component Refactoring
- **New module**: `src/components/combobox/` with `combobox.tsx` and `index.ts`
  - Extracted thin React wrappers over `cmdk` library
  - Renamed all exports: `Command` → `Combobox`, `CommandInput` → `ComboboxInput`, etc.
  - No behavior changes—pure rename for semantic clarity
  
- **Updated consumers** to import from new location:
  - `src/components/command-menu/command-menu.tsx`
  - `src/components/reference/ReferencePicker.tsx`
  - `src/components/filter/filter-components.tsx`
  - `src/components/command-menu/ai-fallback-handler.tsx`
  - Story files in `src/stories/actions/seeking/`

- **Cleaned up exports**:
  - Removed `Command*` re-exports from `src/components/command-menu/index.ts`
  - Updated `src/components/filter/index.ts` to only re-export AI utilities

### Documentation & Stories
- **New Combobox documentation**:
  - `src/stories/operations/Combobox.mdx` — documents the WAI-ARIA contract, checked items, and grouped variants
  - `src/stories/operations/Combobox.stories.tsx` — three stories (Default, Checked, Grouped)
  - `src/stories/operations/Combobox.profile.ts` — generative profile for the pattern

- **Selection pattern stories**:
  - `src/stories/actions/coordination/Selection.stories.tsx` — three stories demonstrating selection patterns:
    - Inline checkboxes (always-visible)
    - Mode-based reveal (toggle to show/hide)
    - Select-all affordance with escalation to "select all matching"
  - Updated `src/stories/actions/coordination/Selection.mdx` to reference new stories

- **Dual listbox placeholder**:
  - `src/stories/actions/coordination/DualListbox.mdx` — seed-stage documentation with situation, forces, and anatomy (no implementation yet)

### Planning Documents
- `plans/active/2026-05-combobox-territory.md` — exec spec for combobox as a component page, multiselect absorption into Selection, and dual listbox placeholder
- `plans/active/2026-05-combobox-primitives-extraction.md` — exec spec for this refactoring (identifier rename map, file changes, scope)
- Updated `plans/index.md` to list active plans

### Cross-linking
- Added precursor links in pattern documentation:
  - `Combobox.mdx` → `CommandMenu.mdx`, `Filtering.mdx`, `Autocomplete.mdx`, `Searching.mdx`
  - `Selection.mdx` → `Combobox.mdx` for multi-select variant
  - `CommandMenu.mdx` → `Combobox.mdx`
  - `Autocomplete.mdx` → `Combobox.mdx`

## Implementation Details

- The rename is **not backwards-compatible**—no shim layer. All consumers updated in one pass per project style.
- `CommandItem` (the data type in `command-menu-types.ts`) retains its name; only the React component is renamed to `ComboboxItem`.
- Internal alias updated: `import { Command as ComboboxPrimitive } from "cmdk"` for consistency.
- JSX types extended in `src/jsx-types.ts` to support new web component attributes (`pp-list`, `pp-list-item`).

https://claude.ai/code/session_01Ly2KCEbzuZ4fNGW2csyZkg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable Combobox component with interactive stories and an Autocomplete demo.
  * Added Selection stories and a Dual Listbox pattern example.

* **Documentation**
  * New and updated docs linking Combobox across patterns (Command menu, Filtering, Autocomplete, Select).
  * Added roadmap/plan entries and a tech-debt item for Dual Listbox.

* **Style**
  * Updated combobox-related styling and list element props for improved behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->